### PR TITLE
feat: use git-smee binary for hooks

### DIFF
--- a/.git-smee.toml
+++ b/.git-smee.toml
@@ -1,0 +1,3 @@
+[[pre-commit]]
+command = "echo pre-commit hook running"
+

--- a/crates/git-smee-cli/Cargo.toml
+++ b/crates/git-smee-cli/Cargo.toml
@@ -3,6 +3,10 @@ name = "git-smee-cli"
 version = "0.1.0"
 edition = "2024"
 
+[[bin]]
+name = "git-smee"
+path = "src/main.rs"
+
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 git-smee-core = { path = "../git-smee-core" }


### PR DESCRIPTION
## Summary
Update the CLI crate configuration so the compiled binary is named `git-smee`, matching the workspace and intended Git subcommand name.

## Changes
- Configure `crates/git-smee-cli/Cargo.toml` with a `[[pre-commit]]` section to emit `git-smee` from `src/main.rs`.

## Rationale
Aligns the installed binary with the expected `git smee` UX and prepares the project for use as a Git subcommand.
