### PR TITLE
Reject unknown hook names in config

### DIFF
--- a/crates/git-smee-core/tests/installer_integration.rs
+++ b/crates/git-smee-core/tests/installer_integration.rs
@@ -43,4 +43,5 @@ fn given_simple_config_when_installing_hooks_then_no_error() {
             .unwrap()
             .contains("git smee run pre-push")
     );
+    assert!(!hooks_dir.join("unknown").exists());
 }


### PR DESCRIPTION
## What changed
- remove the Unknown lifecycle phase fallback used during config deserialization
- fail parsing when .git-smee.toml contains unknown hook keys, preserving the invalid key in the parse error
- add regression tests for single and multiple unknown hook keys
- assert installer integration never writes an unknown hook script

## Validation
- cargo test --workspace
