### PR TITLE
docs: add GitHub issue forms for migration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,68 @@
+name: Bug
+description: Report broken behavior with reproducible details.
+title: "bug: "
+labels:
+  - type:bug
+  - status:todo
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is broken?
+      placeholder: Concise description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Provide exact steps.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected behavior
+      placeholder: Describe what should happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: Actual behavior
+      placeholder: Describe what actually happens.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, shell, version, branch, and any relevant context.
+      placeholder: |
+        - OS:
+        - Shell:
+        - Version:
+        - Branch:
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs and artifacts
+      description: Stack traces, command output, screenshots, or recordings.
+      placeholder: Paste logs or links.
+
+  - type: input
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: Blocking issue numbers, if known.
+      placeholder: "#12"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and discussions
+    url: https://github.com/errfld/git-smee/discussions
+    about: Ask questions that are not actionable issues.

--- a/.github/ISSUE_TEMPLATE/decision.yml
+++ b/.github/ISSUE_TEMPLATE/decision.yml
@@ -1,0 +1,72 @@
+name: Decision
+description: Record an architecture or process decision with rationale.
+title: "decision: "
+labels:
+  - decision
+  - status:todo
+body:
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What problem or constraint requires a decision?
+      placeholder: Describe the context and triggering factors.
+    validations:
+      required: true
+
+  - type: textarea
+    id: decision
+    attributes:
+      label: Decision
+      description: What was decided?
+      placeholder: State the decision clearly.
+    validations:
+      required: true
+
+  - type: textarea
+    id: consequences
+    attributes:
+      label: Consequences
+      description: Expected tradeoffs, risks, and operational impact.
+      placeholder: |
+        Positive:
+        - ...
+
+        Negative:
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What options were considered and why rejected?
+      placeholder: List alternatives and rationale.
+
+  - type: textarea
+    id: links
+    attributes:
+      label: Links and references
+      description: Related issues, PRs, docs, incidents, or discussions.
+      placeholder: Add issue and PR links.
+    validations:
+      required: true
+
+  - type: textarea
+    id: next_action
+    attributes:
+      label: Next action
+      description: Follow-up actions required to implement or communicate this decision.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: input
+    id: superseded_by
+    attributes:
+      label: Superseded by
+      description: If replaced by a newer decision, link it.
+      placeholder: "#123"

--- a/.github/ISSUE_TEMPLATE/memory.yml
+++ b/.github/ISSUE_TEMPLATE/memory.yml
@@ -1,0 +1,72 @@
+name: Memory
+description: Persist durable agent context so future work can reuse it.
+title: "memory: "
+labels:
+  - memory
+  - status:todo
+body:
+  - type: input
+    id: domain
+    attributes:
+      label: Domain
+      description: Memory area (for example, release process, CI, hooks).
+      placeholder: "release process"
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Where this memory came from and why it matters.
+      placeholder: Explain origin and relevance.
+    validations:
+      required: true
+
+  - type: textarea
+    id: memory_statement
+    attributes:
+      label: Memory statement
+      description: The durable fact, rule, or pattern to retain.
+      placeholder: State the memory clearly and unambiguously.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: confidence
+    attributes:
+      label: Confidence
+      options:
+        - high
+        - medium
+        - low
+      default: 1
+    validations:
+      required: true
+
+  - type: textarea
+    id: links
+    attributes:
+      label: Links and evidence
+      description: Supporting issues, PRs, commits, docs, or logs.
+      placeholder: Add traceable references.
+    validations:
+      required: true
+
+  - type: textarea
+    id: next_action
+    attributes:
+      label: Next action
+      description: What should happen next because of this memory?
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: input
+    id: supersedes
+    attributes:
+      label: Supersedes
+      description: Older memory issue replaced by this one.
+      placeholder: "#456"

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,61 @@
+name: Task
+description: Track implementation work with clear scope and acceptance criteria.
+title: "task: "
+labels:
+  - type:task
+  - status:todo
+body:
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: What outcome should this task produce?
+      placeholder: Describe the intended result.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What is in scope and out of scope?
+      placeholder: |
+        In scope:
+        - ...
+
+        Out of scope:
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: Concrete checks for done.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: input
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: Blocking issue numbers, comma-separated (for example, #12, #19).
+      placeholder: "#12, #19"
+
+  - type: input
+    id: parent_issue
+    attributes:
+      label: Parent issue
+      description: If this belongs under an epic, include parent issue number.
+      placeholder: "#35"
+
+  - type: textarea
+    id: links
+    attributes:
+      label: Links and references
+      description: Specs, PRs, commits, or docs.
+      placeholder: Add relevant links.


### PR DESCRIPTION
## Summary
- add GitHub issue form templates for task, bug, decision, and memory records
- add issue template config that disables blank issues and routes questions to discussions
- use structured fields that support agent-readable context and follow-up actions

## Tracking
- closes #37
- part of #35


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented standardized GitHub issue templates for bug reports, feature tasks, architectural decisions, and team memory documentation. Each template includes structured fields and required validations to ensure consistent and comprehensive issue reporting.
  * Disabled blank issue creation to enforce structured reporting and configured a discussion link to direct non-actionable questions appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->