### PR TITLE
docs: fix GitHub comment newline formatting guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,24 @@ gh issue create --title "..." --body-file <file> --label type:task --label statu
 gh issue close <number> --comment "Completed in <commit-or-pr>"
 ```
 
+## Comment Formatting (GitHub CLI)
+
+Use real newlines for multi-line comments. Do **not** put `\n` inside normal quoted strings (for example, `"line1\nline2"`), because the shell passes it literally and GitHub renders `\n` as text. This applies to both `gh issue comment` and `gh pr comment`.
+
+```bash
+# Preferred: write multiline issue comments via stdin
+gh issue comment <number> --body-file - <<'EOF'
+Addressed all requested review updates in commit <sha>:
+- item 1
+- item 2
+
+Both unresolved review threads are now marked resolved.
+EOF
+
+# Then close separately (or keep one-line close comments only)
+gh issue close <number> --comment "Completed in <commit-or-pr>"
+```
+
 ## Dependencies and Hierarchy
 
 Use native GitHub relationships (not markdown-only links):


### PR DESCRIPTION
## Summary
- add a new `Comment Formatting (GitHub CLI)` section to `AGENTS.md`
- explain why `\n` inside normal quoted strings is rendered literally in GitHub comments
- provide a multiline-safe pattern using `gh issue comment --body-file - <<'EOF' ... EOF`
- clarify this applies to both `gh issue comment` and `gh pr comment`

## Why
Using `--comment "line1\\nline2"` sends a literal backslash-n sequence, so GitHub shows `\n` instead of line breaks.

## Testing
- docs-only change; verified examples and command syntax with `gh ... --help`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new guidance on comment formatting best practices, including examples for properly handling multi-line comments in command-line operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->