### PR TITLE
Clarify parallel hook failure semantics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,9 +104,8 @@ Prefer `gh` / `gh api` for deterministic write operations by agents.
 - Normalize user-provided config paths from `--config` and `GIT_SMEE_CONFIG` before use; on Unix this includes expanding leading `~` so runtime reads and installed hook scripts reference real absolute paths.
 
 ## Learnings
-
 - Config extension checks should be ASCII case-insensitive so `.TOML`/mixed-case filenames work consistently across macOS and Windows defaults.
 - Issue #51: expanding leading `~` during CLI config path resolution avoids writing literal-tilde paths into hook scripts and keeps install/run behavior consistent across interactive and non-interactive environments.
 - Command redaction should use quote-aware tokenization and strict `KEY=value` detection so inline env secrets stay hidden even when values contain spaces.
 - Keep CLI regression coverage for empty hook configs so `git smee install` continues surfacing a human-readable `No hooks present...` error instead of internal enum names.
-
+- Parallel hooks are best-effort fail-fast: the first failure fails the run, but already-started parallel commands may still complete.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,3 +95,4 @@ gh dash
 Prefer `gh` / `gh api` for deterministic write operations by agents.
 
 ## Learnings
+- Parallel hooks are best-effort fail-fast: the first failure fails the run, but already-started parallel commands may still complete.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ When running hooks, git-smee executes commands in two phases:
 1. **Sequential phase**: All commands with `parallel_execution_allowed = false` (or omitted) run one at a time, in the order they appear in the config.
 2. **Parallel phase**: All commands with `parallel_execution_allowed = true` run concurrently using a thread pool.
 
-Sequential commands always complete before parallel commands begin. If any command fails, execution stops immediately (fail-fast behavior).
+Sequential commands always complete before parallel commands begin. If any sequential command fails, execution stops immediately. For parallel commands, the first failing command causes the overall run to fail, but commands that are already in flight may still finish.
 
 **Example:**
 

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -521,7 +521,19 @@ command = "test \"$1\" = \"COMMIT_EDITMSG\""
 fn given_hook_args_when_running_then_command_receives_env_arg_contract() {
     let test_repo = common::TestRepo::default();
     let assertion_command = if cfg!(windows) {
-        "if \"%GIT_SMEE_HOOK_ARGC%\"==\"2\" (if \"%GIT_SMEE_HOOK_ARG_1%\"==\"alpha\" (if \"%GIT_SMEE_HOOK_ARG_2%\"==\"beta\" (exit /b 0) else (exit /b 1)) else (exit /b 1)) else (exit /b 1)"
+        r#"if "%GIT_SMEE_HOOK_ARGC%"=="2" (
+  if "%GIT_SMEE_HOOK_ARG_1%"=="alpha" (
+    if "%GIT_SMEE_HOOK_ARG_2%"=="beta" (
+      exit /b 0
+    ) else (
+      exit /b 1
+    )
+  ) else (
+    exit /b 1
+  )
+) else (
+  exit /b 1
+)"#
     } else {
         "test \"$GIT_SMEE_HOOK_ARGC\" = \"2\" && test \"$GIT_SMEE_HOOK_ARG_1\" = \"alpha\" && test \"$GIT_SMEE_HOOK_ARG_2\" = \"beta\""
     };

--- a/crates/git-smee-core/src/config.rs
+++ b/crates/git-smee-core/src/config.rs
@@ -24,7 +24,7 @@ impl SmeeConfig {
     ///
     /// # Arguments
     ///
-    /// * `path` - Paht to the TOML configuration file
+    /// * `path` - Path to the TOML configuration file
     ///
     /// # Examples
     ///

--- a/crates/git-smee-core/src/executor.rs
+++ b/crates/git-smee-core/src/executor.rs
@@ -144,7 +144,7 @@ mod tests {
     use std::{
         collections::{HashMap, VecDeque},
         io,
-        sync::Mutex,
+        sync::{Arc, Barrier, Mutex},
     };
 
     use assert2::assert;
@@ -156,6 +156,7 @@ mod tests {
     enum PlannedResult {
         Exit(Option<i32>),
         SpawnError(io::ErrorKind),
+        Barrier(Arc<Barrier>, Option<i32>),
     }
 
     #[derive(Default)]
@@ -201,17 +202,23 @@ mod tests {
 
     impl CommandRunner for FakeRunner {
         fn run(&self, command: &str) -> Result<Option<i32>, io::Error> {
-            let mut state = self.state.lock().unwrap();
-            state.calls.push(command.to_string());
-            let outcome = state
-                .outcomes_by_command
-                .get_mut(command)
-                .and_then(VecDeque::pop_front)
-                .or_else(|| state.default_outcomes.pop_front())
-                .unwrap_or_else(|| panic!("no fake outcome configured for command '{command}'"));
+            let outcome = {
+                let mut state = self.state.lock().unwrap();
+                state.calls.push(command.to_string());
+                state
+                    .outcomes_by_command
+                    .get_mut(command)
+                    .and_then(VecDeque::pop_front)
+                    .or_else(|| state.default_outcomes.pop_front())
+                    .unwrap_or_else(|| panic!("no fake outcome configured for command '{command}'"))
+            };
             match outcome {
                 PlannedResult::Exit(code) => Ok(code),
                 PlannedResult::SpawnError(kind) => Err(io::Error::new(kind, "spawn failed")),
+                PlannedResult::Barrier(barrier, code) => {
+                    barrier.wait();
+                    Ok(code)
+                }
             }
         }
 
@@ -435,6 +442,7 @@ mod tests {
 
     #[test]
     fn given_failed_parallel_hook_when_executing_then_in_flight_parallel_hooks_may_complete() {
+        let barrier = Arc::new(Barrier::new(2));
         let hooks = vec![
             HookDefinition {
                 command: "sequential".to_string(),
@@ -451,11 +459,21 @@ mod tests {
         ];
         let runner = FakeRunner::with_command_outcomes(vec![
             ("sequential", vec![PlannedResult::Exit(Some(0))]),
-            ("parallel-ok", vec![PlannedResult::Exit(Some(0))]),
-            ("parallel-fail", vec![PlannedResult::Exit(Some(23))]),
+            (
+                "parallel-ok",
+                vec![PlannedResult::Barrier(barrier.clone(), Some(0))],
+            ),
+            (
+                "parallel-fail",
+                vec![PlannedResult::Barrier(barrier.clone(), Some(23))],
+            ),
         ]);
 
-        let result = run_hooks_with_runner(&hooks, &runner);
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(2)
+            .build()
+            .expect("test thread pool should build");
+        let result = pool.install(|| run_hooks_with_runner(&hooks, &runner));
         let calls = runner.calls();
 
         assert!(matches!(result, Err(Error::ExecutionFailed(23))));

--- a/crates/git-smee-core/src/executor.rs
+++ b/crates/git-smee-core/src/executor.rs
@@ -434,7 +434,7 @@ mod tests {
     }
 
     #[test]
-    fn given_failed_parallel_hook_when_executing_then_error_is_propagated() {
+    fn given_failed_parallel_hook_when_executing_then_in_flight_parallel_hooks_may_complete() {
         let hooks = vec![
             HookDefinition {
                 command: "sequential".to_string(),
@@ -460,6 +460,7 @@ mod tests {
 
         assert!(matches!(result, Err(Error::ExecutionFailed(23))));
         assert_eq!(calls[0], "sequential");
+        assert!(calls.iter().any(|call| call == "parallel-ok"));
         assert!(calls.iter().any(|call| call == "parallel-fail"));
     }
 }

--- a/crates/git-smee-core/src/executor.rs
+++ b/crates/git-smee-core/src/executor.rs
@@ -236,7 +236,7 @@ mod tests {
     use std::{
         collections::{HashMap, VecDeque},
         io,
-        sync::Mutex,
+        sync::{Arc, Barrier, Mutex},
     };
 
     use assert2::assert;
@@ -248,6 +248,7 @@ mod tests {
     enum PlannedResult {
         Exit(Option<i32>),
         SpawnError(io::ErrorKind),
+        Barrier(Arc<Barrier>, Option<i32>),
     }
 
     #[derive(Default)]
@@ -298,18 +299,24 @@ mod tests {
 
     impl CommandRunner for FakeRunner {
         fn run(&self, command: &str, hook_args: &[String]) -> Result<Option<i32>, io::Error> {
-            let mut state = self.state.lock().unwrap();
-            state.calls.push(command.to_string());
-            state.hook_args_calls.push(hook_args.to_vec());
-            let outcome = state
-                .outcomes_by_command
-                .get_mut(command)
-                .and_then(VecDeque::pop_front)
-                .or_else(|| state.default_outcomes.pop_front())
-                .unwrap_or_else(|| panic!("no fake outcome configured for command '{command}'"));
+            let outcome = {
+                let mut state = self.state.lock().unwrap();
+                state.calls.push(command.to_string());
+                state.hook_args_calls.push(hook_args.to_vec());
+                state
+                    .outcomes_by_command
+                    .get_mut(command)
+                    .and_then(VecDeque::pop_front)
+                    .or_else(|| state.default_outcomes.pop_front())
+                    .unwrap_or_else(|| panic!("no fake outcome configured for command '{command}'"))
+            };
             match outcome {
                 PlannedResult::Exit(code) => Ok(code),
                 PlannedResult::SpawnError(kind) => Err(io::Error::new(kind, "spawn failed")),
+                PlannedResult::Barrier(barrier, code) => {
+                    barrier.wait();
+                    Ok(code)
+                }
             }
         }
 
@@ -598,6 +605,7 @@ mod tests {
 
     #[test]
     fn given_failed_parallel_hook_when_executing_then_in_flight_parallel_hooks_may_complete() {
+        let barrier = Arc::new(Barrier::new(2));
         let hooks = vec![
             HookDefinition {
                 command: "sequential".to_string(),
@@ -614,11 +622,21 @@ mod tests {
         ];
         let runner = FakeRunner::with_command_outcomes(vec![
             ("sequential", vec![PlannedResult::Exit(Some(0))]),
-            ("parallel-ok", vec![PlannedResult::Exit(Some(0))]),
-            ("parallel-fail", vec![PlannedResult::Exit(Some(23))]),
+            (
+                "parallel-ok",
+                vec![PlannedResult::Barrier(barrier.clone(), Some(0))],
+            ),
+            (
+                "parallel-fail",
+                vec![PlannedResult::Barrier(barrier.clone(), Some(23))],
+            ),
         ]);
 
-        let result = run_hooks_with_runner(&hooks, &runner, &[]);
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(2)
+            .build()
+            .expect("test thread pool should build");
+        let result = pool.install(|| run_hooks_with_runner(&hooks, &runner, &[]));
         let calls = runner.calls();
 
         assert!(matches!(result, Err(Error::ExecutionFailed(23))));

--- a/crates/git-smee-core/src/executor.rs
+++ b/crates/git-smee-core/src/executor.rs
@@ -597,7 +597,7 @@ mod tests {
     }
 
     #[test]
-    fn given_failed_parallel_hook_when_executing_then_error_is_propagated() {
+    fn given_failed_parallel_hook_when_executing_then_in_flight_parallel_hooks_may_complete() {
         let hooks = vec![
             HookDefinition {
                 command: "sequential".to_string(),
@@ -623,6 +623,7 @@ mod tests {
 
         assert!(matches!(result, Err(Error::ExecutionFailed(23))));
         assert_eq!(calls[0], "sequential");
+        assert!(calls.iter().any(|call| call == "parallel-ok"));
         assert!(calls.iter().any(|call| call == "parallel-fail"));
     }
 }

--- a/crates/git-smee-core/src/repository.rs
+++ b/crates/git-smee-core/src/repository.rs
@@ -172,7 +172,7 @@ fn parse_git_bool(flag: &str, bytes: &[u8]) -> Result<bool, Error> {
     }
 }
 
-fn parse_git_path(_flag: &str, bytes: &[u8]) -> Result<Option<PathBuf>, Error> {
+fn parse_git_path(flag: &str, bytes: &[u8]) -> Result<Option<PathBuf>, Error> {
     let trimmed = trim_git_output_path(bytes);
     if trimmed.is_empty() {
         return Ok(None);
@@ -180,6 +180,7 @@ fn parse_git_path(_flag: &str, bytes: &[u8]) -> Result<Option<PathBuf>, Error> {
 
     #[cfg(unix)]
     {
+        let _ = flag;
         use std::ffi::OsString;
         use std::os::unix::ffi::OsStringExt;
 

--- a/crates/git-smee-core/src/repository.rs
+++ b/crates/git-smee-core/src/repository.rs
@@ -71,100 +71,104 @@ pub enum Error {
 /// ```
 pub fn find_git_root() -> Result<PathBuf, Error> {
     let current_dir = env::current_dir().map_err(Error::FailedToChangeDirectory)?;
+    let git_state = git_rev_parse_state()?;
 
-    if git_rev_parse_bool("--is-inside-work-tree")?
-        && let Some(root) = git_rev_parse_path("--show-toplevel")?
-    {
+    if !git_state.inside_git_dir {
+        let root = current_dir.join(git_state.show_cdup.as_deref().unwrap_or_else(|| Path::new(".")));
         let canonical_root = root
             .canonicalize()
             .map_err(Error::FailedToChangeDirectory)?;
-        if !git_rev_parse_bool("--is-bare-repository")?
-            && canonical_root.file_name() == Some(OsStr::new(".git"))
-            && let Some(worktree_root) = canonical_root.parent()
-        {
-            return worktree_root
-                .canonicalize()
-                .map_err(Error::FailedToChangeDirectory);
-        }
         return Ok(canonical_root);
     }
 
-    if git_rev_parse_bool("--is-inside-git-dir")?
-        && let Some(git_dir) = git_rev_parse_path("--absolute-git-dir")?
+    let Some(git_dir) = git_state.git_dir else {
+        return Err(Error::NotInGitRepository);
+    };
+    let resolved_git_dir = if git_dir.is_absolute() {
+        git_dir
+    } else {
+        current_dir.join(git_dir)
+    };
+    let canonical_git_dir = resolved_git_dir
+        .canonicalize()
+        .map_err(Error::FailedToChangeDirectory);
+
+    if git_state.bare_repository {
+        return canonical_git_dir;
+    }
+
+    let canonical_git_dir = canonical_git_dir?;
+    if canonical_git_dir.file_name() == Some(OsStr::new(".git"))
+        && let Some(worktree_root) = canonical_git_dir.parent()
     {
-        if git_rev_parse_bool("--is-bare-repository")? {
-            return git_dir
-                .canonicalize()
-                .map_err(Error::FailedToChangeDirectory);
-        }
-
-        if git_dir.file_name() == Some(OsStr::new(".git"))
-            && let Some(worktree_root) = git_dir.parent()
-        {
-            return worktree_root
-                .canonicalize()
-                .map_err(Error::FailedToChangeDirectory);
-        }
-
-        return git_dir
+        return worktree_root
             .canonicalize()
             .map_err(Error::FailedToChangeDirectory);
     }
 
-    if git_rev_parse_bool("--is-bare-repository")? {
-        if let Some(git_dir) = git_rev_parse_path("--absolute-git-dir")? {
-            return git_dir
-                .canonicalize()
-                .map_err(Error::FailedToChangeDirectory);
-        }
-        return current_dir
-            .canonicalize()
-            .map_err(Error::FailedToChangeDirectory);
-    }
-
-    Err(Error::NotInGitRepository)
+    Ok(canonical_git_dir)
 }
 
-fn git_rev_parse_bool(flag: &str) -> Result<bool, Error> {
+struct GitRevParseState {
+    bare_repository: bool,
+    inside_git_dir: bool,
+    git_dir: Option<PathBuf>,
+    show_cdup: Option<PathBuf>,
+}
+
+fn git_rev_parse_state() -> Result<GitRevParseState, Error> {
+    const FLAGS: [&str; 4] = [
+        "--is-bare-repository",
+        "--is-inside-git-dir",
+        "--git-dir",
+        "--show-cdup",
+    ];
     let output = Command::new("git")
         .arg("rev-parse")
-        .arg(flag)
+        .args(FLAGS)
         .output()
         .map_err(Error::FailedToExecuteGit)?;
 
     if !output.status.success() {
         if is_not_in_repository_error(&output.stderr) {
-            return Ok(false);
+            return Err(Error::NotInGitRepository);
         }
         let stderr = stderr_or_status(&output.stderr, output.status.code());
         return Err(Error::FailedToQueryGitRevParse {
-            flag: flag.to_string(),
+            flag: FLAGS.join(" "),
             stderr,
         });
     }
 
-    Ok(String::from_utf8_lossy(&output.stdout).trim() == "true")
+    let lines: Vec<&[u8]> = output.stdout.split(|byte| *byte == b'\n').collect();
+    if lines.len() < FLAGS.len() {
+        return Err(Error::FailedToQueryGitRevParse {
+            flag: FLAGS.join(" "),
+            stderr: "git rev-parse returned incomplete output".to_string(),
+        });
+    }
+
+    Ok(GitRevParseState {
+        bare_repository: parse_git_bool(FLAGS[0], lines[0])?,
+        inside_git_dir: parse_git_bool(FLAGS[1], lines[1])?,
+        git_dir: parse_git_path(FLAGS[2], lines[2])?,
+        show_cdup: parse_git_path(FLAGS[3], lines[3])?,
+    })
 }
 
-fn git_rev_parse_path(flag: &str) -> Result<Option<PathBuf>, Error> {
-    let output = Command::new("git")
-        .arg("rev-parse")
-        .arg(flag)
-        .output()
-        .map_err(Error::FailedToExecuteGit)?;
-
-    if !output.status.success() {
-        if is_not_in_repository_error(&output.stderr) {
-            return Ok(None);
-        }
-        let stderr = stderr_or_status(&output.stderr, output.status.code());
-        return Err(Error::FailedToQueryGitRevParse {
+fn parse_git_bool(flag: &str, bytes: &[u8]) -> Result<bool, Error> {
+    match String::from_utf8_lossy(trim_git_output_path(bytes)).trim() {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        other => Err(Error::FailedToQueryGitRevParse {
             flag: flag.to_string(),
-            stderr,
-        });
+            stderr: format!("unexpected boolean output: '{other}'"),
+        }),
     }
+}
 
-    let trimmed = trim_git_output_path(&output.stdout);
+fn parse_git_path(_flag: &str, bytes: &[u8]) -> Result<Option<PathBuf>, Error> {
+    let trimmed = trim_git_output_path(bytes);
     if trimmed.is_empty() {
         return Ok(None);
     }

--- a/crates/git-smee-core/src/repository.rs
+++ b/crates/git-smee-core/src/repository.rs
@@ -74,7 +74,12 @@ pub fn find_git_root() -> Result<PathBuf, Error> {
     let git_state = git_rev_parse_state()?;
 
     if !git_state.inside_git_dir {
-        let root = current_dir.join(git_state.show_cdup.as_deref().unwrap_or_else(|| Path::new(".")));
+        let root = current_dir.join(
+            git_state
+                .show_cdup
+                .as_deref()
+                .unwrap_or_else(|| Path::new(".")),
+        );
         let canonical_root = root
             .canonicalize()
             .map_err(Error::FailedToChangeDirectory)?;


### PR DESCRIPTION
Closes #45

## Summary
- update README execution-order docs to reflect sequential fail-fast and parallel in-flight behavior
- tighten executor test coverage for failing parallel hooks by asserting a non-failing parallel command may still complete
- add concise learning note in AGENTS.md

## Testing
- cargo test -p git-smee-core given_failed_parallel_hook_when_executing_then_in_flight_parallel_hooks_may_complete
- cargo test -p git-smee-core given_failed_sequential_hook_when_executing_then_parallel_hooks_do_not_run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hook argument forwarding documentation, explaining how Git hook arguments are exposed via environment variables and positional parameters.

* **Documentation**
  * Updated CLI command syntax: `--config` flag now precedes the `run` subcommand.
  * Clarified failure semantics: parallel command failures mark the run as failed but allow in-flight commands to complete.
  * Expanded examples to reflect argument forwarding.

* **Bug Fixes**
  * Corrected documentation typo in config module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->