### PR TITLE
Add CLI regression test for empty config install failure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,3 +95,4 @@ gh dash
 Prefer `gh` / `gh api` for deterministic write operations by agents.
 
 ## Learnings
+- Keep CLI regression coverage for empty hook configs so `git smee install` continues surfacing a human-readable `No hooks present...` error instead of internal enum names.

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -129,6 +129,22 @@ command = "   "
 }
 
 #[test]
+fn given_empty_config_when_install_then_no_hooks_present_error_is_reported() {
+    let test_repo = common::TestRepo::default();
+    test_repo.write_config("");
+
+    let mut cmd = Command::new(cargo::cargo_bin!("git-smee"));
+    cmd.current_dir(&test_repo.path)
+        .arg("install")
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("Error: No hooks present in the configuration to install")
+                .and(predicate::str::contains("NoHooksPresent").not()),
+        );
+}
+
+#[test]
 fn given_existing_config_when_init_without_force_then_it_refuses_to_overwrite() {
     let test_repo = common::TestRepo::default();
     let original = fs::read_to_string(test_repo.config_path()).unwrap();


### PR DESCRIPTION
Closes #52

## Summary
- add CLI integration regression coverage for `git smee install` with an empty config
- assert stderr includes the user-facing `No hooks present...` message
- assert stderr does not leak internal enum variant names
- add concise learning note in AGENTS.md

## Testing
- cargo test -p git-smee-cli given_empty_config_when_install_then_no_hooks_present_error_is_reported
