### PR TITLE
fix: explicit error when --config points to a directory

### DIFF
--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -103,6 +103,27 @@ fn given_missing_config_when_install_then_user_friendly_error() {
 }
 
 #[test]
+fn given_directory_config_when_install_then_user_friendly_not_a_file_error() {
+    let test_repo = common::TestRepo::default();
+    let config_dir = test_repo.path.join("conf.toml");
+    fs::create_dir_all(&config_dir).expect("failed to create config directory");
+
+    let mut cmd = Command::new(cargo::cargo_bin!("git-smee"));
+    cmd.current_dir(&test_repo.path)
+        .arg("--config")
+        .arg(&config_dir)
+        .arg("install")
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains(
+                "Error: The specified configuration path exists but is not a regular file",
+            )
+            .and(predicate::str::contains("NotAFile").not()),
+        );
+}
+
+#[test]
 fn given_invalid_config_when_install_then_validation_error_is_reported() {
     let test_repo = common::TestRepo::default();
     test_repo.write_config(

--- a/crates/git-smee-core/src/config.rs
+++ b/crates/git-smee-core/src/config.rs
@@ -49,8 +49,11 @@ impl SmeeConfig {
     /// ```
     ///
     pub fn from_toml(path: &Path) -> Result<Self, Error> {
-        if !path.exists() || !path.is_file() {
+        if !path.exists() {
             return Err(Error::MissingFile);
+        }
+        if !path.is_file() {
+            return Err(Error::NotAFile);
         }
         let ext = path.extension().ok_or(Error::CanNotReadExtension)?;
         if ext != "toml" {
@@ -218,6 +221,8 @@ impl fmt::Display for LifeCyclePhase {
 pub enum Error {
     #[error("The specified configuration file is missing")]
     MissingFile,
+    #[error("The specified configuration path exists but is not a regular file")]
+    NotAFile,
     #[error("The specified configuration file does not have a readable extension")]
     CanNotReadExtension,
     #[error("The specified configuration file does not have a .toml extension")]

--- a/crates/git-smee-core/tests/config_integration.rs
+++ b/crates/git-smee-core/tests/config_integration.rs
@@ -32,6 +32,17 @@ fn given_invalid_path_when_reading_then_error() {
 }
 
 #[test]
+fn given_directory_path_when_reading_then_error_is_not_a_file() {
+    let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+    let config_dir = temp_dir.path().join("conf.toml");
+    fs::create_dir_all(&config_dir).expect("failed to create config directory fixture");
+
+    let result = SmeeConfig::from_toml(&config_dir);
+
+    assert!(matches!(result, Err(config::Error::NotAFile)));
+}
+
+#[test]
 fn given_yaml_file_when_reading_then_error() {
     let path = PathBuf::from("tests/fixtures/wrong_extension.yaml");
     let result = SmeeConfig::from_toml(&path);


### PR DESCRIPTION
## Summary
- distinguish missing config paths from existing non-file paths
- add core config integration coverage for directory paths
- add CLI coverage for the user-facing non-file error message

## Validation
- `cargo test -p git-smee-core -p git-smee-cli`

Closes #63


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for configuration file validation. The system now provides clearer error messages when a directory is provided as a configuration path instead of a file.

* **Tests**
  * Added test coverage for configuration path validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->