### PR TITLE
fix: keep default config path portable in installed hooks

### DIFF
--- a/crates/git-smee-cli/src/main.rs
+++ b/crates/git-smee-cli/src/main.rs
@@ -135,6 +135,10 @@ fn is_default_config_path(config_path: &Path) -> bool {
 }
 
 fn normalize_config_path_for_hook_script(config_path: &Path) -> PathBuf {
+    if is_default_config_path(config_path) {
+        return config_path.to_path_buf();
+    }
+
     if config_path.is_absolute() {
         return config_path.to_path_buf();
     }

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -416,6 +416,26 @@ command = "echo custom"
 }
 
 #[test]
+fn given_default_config_when_installing_then_hook_script_keeps_portable_relative_path() {
+    let test_repo = common::TestRepo::default();
+
+    let mut cmd = Command::new(cargo::cargo_bin!("git-smee"));
+    cmd.current_dir(&test_repo.path)
+        .arg("install")
+        .assert()
+        .success();
+
+    let hook_content =
+        fs::read_to_string(test_repo.path.join(".git/hooks/pre-commit")).expect("missing hook");
+
+    #[cfg(unix)]
+    assert!(hook_content.contains("GIT_SMEE_CONFIG='.git-smee.toml'"));
+
+    #[cfg(windows)]
+    assert!(hook_content.contains("set \"GIT_SMEE_CONFIG=.git-smee.toml\""));
+}
+
+#[test]
 fn given_special_character_config_path_when_installing_then_hook_script_escapes_path() {
     let test_repo = common::TestRepo::default();
     let custom_config = test_repo.write_config_at(


### PR DESCRIPTION
## Summary
- keep `.git-smee.toml` repo-relative when rendering hook scripts
- preserve existing absolute normalization for explicit custom config paths
- add CLI regression coverage for default path rendering in installed wrappers

## Validation
- `cargo test -p git-smee-core -p git-smee-cli`

Closes #65


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed configuration file path handling in pre-commit hook scripts to preserve portable relative paths for the default configuration instead of converting them to absolute paths, improving cross-system compatibility and setup portability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->