### PR TITLE
Harden CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,13 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -11,94 +18,228 @@ jobs:
   build-and-test:
     name: Build & test (${{ matrix.toolchain }})
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     strategy:
       matrix:
         toolchain: [stable, beta, nightly]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust (${{ matrix.toolchain }})
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: ${{ matrix.toolchain }}
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Build
-        run: cargo build --workspace --all-targets --verbose
+        run: cargo build --workspace --all-targets --all-features --locked --verbose
 
       - name: Test
-        run: cargo test --workspace --verbose
+        run: cargo test --workspace --all-features --locked --verbose -- --skip repository::tests::
 
-  windows-build-and-test:
-    name: Build & test (windows, stable)
-    runs-on: windows-latest
+  macos-build-and-test:
+    name: Build & test (macOS, stable)
+    runs-on: macos-latest
+    timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Build
-        run: cargo build --workspace --all-targets --verbose
+        run: cargo build --workspace --all-targets --all-features --locked --verbose
 
       - name: Test
-        run: cargo test --workspace --verbose
+        run: cargo test --workspace --all-features --locked --verbose -- --skip repository::tests::
+
+  windows-build-and-test:
+    name: Build & test (windows, stable)
+    runs-on: windows-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Build
+        run: cargo build --workspace --all-targets --all-features --locked --verbose
+
+      - name: Test
+        run: cargo test --workspace --all-features --locked --verbose -- --skip repository::tests::
+
+  msrv-build-and-test:
+    name: Build & test (MSRV 1.85.0)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust (1.85.0)
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: 1.85.0
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Build
+        run: cargo build --workspace --all-targets --all-features --locked --verbose
+
+      - name: Test
+        run: cargo test --workspace --all-features --locked --verbose -- --skip repository::tests::
 
   lint:
     name: Lint (fmt + clippy, stable)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
           components: rustfmt, clippy
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Format check
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+
+  workflow-lint:
+    name: Workflow lint (actionlint + shellcheck)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+
+      - name: Run actionlint
+        uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
+
+      - name: Lint Unix hook template
+        run: |
+          sed \
+            -e 's|{git_smee_executable}|/tmp/git-smee|g' \
+            -e 's|{config_path}|/tmp/.git-smee.toml|g' \
+            -e 's|{hook}|pre-commit|g' \
+            crates/git-smee-core/src/scripts/hook_template_unix > /tmp/git-smee-hook-template.sh
+          shellcheck /tmp/git-smee-hook-template.sh
+
+  security-advisories:
+    name: Security advisories (stable)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@de6f06126afb86b5250a16ff961c57360c5edccc # v2
+        with:
+          tool: cargo-audit
+
+      - name: Audit dependencies
+        run: cargo audit
 
   coverage:
     name: Coverage (stable)
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust (stable) + llvm-tools
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
           components: llvm-tools-preview
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@de6f06126afb86b5250a16ff961c57360c5edccc # v2
         with:
           tool: cargo-llvm-cov
 
+      - name: Enforce coverage floor
+        run: cargo llvm-cov --workspace --all-features --locked --summary-only --fail-under-lines 70 -- --skip repository::tests::
+
       - name: Run coverage
         run: |
-          cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
+          cargo llvm-cov --workspace --all-features --locked --lcov --output-path lcov.info -- --skip repository::tests::
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-lcov
           path: lcov.info
+
+  repository-tests-serialized:
+    name: Repository tests (serialized guard)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Run serialized repository tests
+        run: cargo test -p git-smee-core --lib --locked repository::tests:: -- --test-threads=1
+
+  repository-tests-flake-detection:
+    name: Repository tests (flake detection)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Repeat repository tests to catch env/cwd flakes
+        run: |
+          for attempt in 1 2 3 4 5; do
+            echo "flake detection attempt $attempt"
+            cargo test -p git-smee-core --lib --locked --verbose repository::tests::
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,15 +24,15 @@ jobs:
         toolchain: [stable, beta, nightly]
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Install Rust (${{ matrix.toolchain }})
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # master
         with:
           toolchain: ${{ matrix.toolchain }}
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
 
       - name: Build
         run: cargo build --workspace --all-targets --all-features --locked --verbose
@@ -241,5 +241,5 @@ jobs:
         run: |
           for attempt in 1 2 3 4 5; do
             echo "flake detection attempt $attempt"
-            cargo test -p git-smee-core --lib --locked --verbose repository::tests::
+            cargo test -p git-smee-core --lib --locked --verbose repository::tests:: -- --test-threads=1
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: cargo build --workspace --all-targets --all-features --locked --verbose
 
       - name: Test
-        run: cargo test --workspace --all-features --locked --verbose -- --skip repository::tests::
+        run: "cargo test --workspace --all-features --locked --verbose -- --skip repository::tests::"
 
   macos-build-and-test:
     name: Build & test (macOS, stable)
@@ -59,7 +59,7 @@ jobs:
         run: cargo build --workspace --all-targets --all-features --locked --verbose
 
       - name: Test
-        run: cargo test --workspace --all-features --locked --verbose -- --skip repository::tests::
+        run: "cargo test --workspace --all-features --locked --verbose -- --skip repository::tests::"
 
   windows-build-and-test:
     name: Build & test (windows, stable)
@@ -80,7 +80,7 @@ jobs:
         run: cargo build --workspace --all-targets --all-features --locked --verbose
 
       - name: Test
-        run: cargo test --workspace --all-features --locked --verbose -- --skip repository::tests::
+        run: "cargo test --workspace --all-features --locked --verbose -- --skip repository::tests::"
 
   msrv-build-and-test:
     name: Build & test (MSRV 1.85.0)
@@ -101,7 +101,7 @@ jobs:
         run: cargo build --workspace --all-targets --all-features --locked --verbose
 
       - name: Test
-        run: cargo test --workspace --all-features --locked --verbose -- --skip repository::tests::
+        run: "cargo test --workspace --all-features --locked --verbose -- --skip repository::tests::"
 
   lint:
     name: Lint (fmt + clippy, stable)
@@ -192,7 +192,7 @@ jobs:
           tool: cargo-llvm-cov
 
       - name: Enforce coverage floor
-        run: cargo llvm-cov --workspace --all-features --locked --summary-only --fail-under-lines 70 -- --skip repository::tests::
+        run: "cargo llvm-cov --workspace --all-features --locked --summary-only --fail-under-lines 70 -- --skip repository::tests::"
 
       - name: Run coverage
         run: |
@@ -220,7 +220,7 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Run serialized repository tests
-        run: cargo test -p git-smee-core --lib --locked repository::tests:: -- --test-threads=1
+        run: "cargo test -p git-smee-core --lib --locked repository::tests:: -- --test-threads=1"
 
   repository-tests-flake-detection:
     name: Repository tests (flake detection)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,16 +83,16 @@ jobs:
         run: "cargo test --workspace --all-features --locked --verbose -- --skip repository::tests::"
 
   msrv-build-and-test:
-    name: Build & test (MSRV 1.85.0)
+    name: Build & test (MSRV 1.88.0)
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Install Rust (1.85.0)
+      - name: Install Rust (1.88.0)
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: 1.85.0
+          toolchain: 1.88.0
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,67 +12,149 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always
-  TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
 
 jobs:
+  prepare-release:
+    name: Prepare release inputs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      tag: ${{ steps.validate.outputs.tag }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - id: validate
+        name: Validate release tag
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            raw_tag='${{ github.event.inputs.tag }}'
+            tag="$(printf '%s' "$raw_tag" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+          else
+            tag='${{ github.ref_name }}'
+          fi
+
+          if ! printf '%s' "$tag" | grep -Eq '^v[0-9]+(\.[0-9]+)*([-.].*)?$'; then
+            echo "invalid release tag: '$tag'" >&2
+            exit 1
+          fi
+
+          if ! git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+            echo "release tag '$tag' does not exist in this repository" >&2
+            exit 1
+          fi
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
   build-and-release:
+    needs: prepare-release
     name: Build ${{ matrix.target }} binary
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    permissions:
+      contents: write
     strategy:
       matrix:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            archive_ext: tar.gz
           - os: macos-latest
             target: aarch64-apple-darwin
-            archive_ext: tar.gz
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-          ref: ${{ env.TAG }}
+          ref: ${{ needs.prepare-release.outputs.tag }}
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Build release binary
-        run: cargo build --release -p git-smee-cli --target ${{ matrix.target }}
+        run: cargo build --release --locked -p git-smee-cli --target ${{ matrix.target }}
 
-      - name: Prepare artifact
+      - id: package-unix
+        if: runner.os != 'Windows'
+        name: Prepare Unix artifact
+        shell: bash
         run: |
-          VERSION=${TAG}
+          VERSION='${{ needs.prepare-release.outputs.tag }}'
+          ASSET="git-smee-${VERSION}-${{ matrix.target }}.tar.gz"
           mkdir -p dist
           cp target/${{ matrix.target }}/release/git-smee dist/
-          tar -czf git-smee-${VERSION}-${{ matrix.target }}.${{ matrix.archive_ext }} -C dist git-smee
+          test -f dist/git-smee
+          tar -czf "$ASSET" -C dist git-smee
+          shasum -a 256 "$ASSET" > "$ASSET.sha256"
+          echo "asset=$ASSET" >> "$GITHUB_OUTPUT"
+          echo "checksum=$ASSET.sha256" >> "$GITHUB_OUTPUT"
 
-      - name: Upload release asset
-        uses: softprops/action-gh-release@v2
+      - id: package-windows
+        if: runner.os == 'Windows'
+        name: Prepare Windows artifact
+        shell: pwsh
+        run: |
+          $version = '${{ needs.prepare-release.outputs.tag }}'
+          $asset = "git-smee-$version-${{ matrix.target }}.zip"
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
+          Copy-Item "target/${{ matrix.target }}/release/git-smee.exe" "dist/git-smee.exe"
+          if (-not (Test-Path "dist/git-smee.exe")) {
+            throw "missing git-smee.exe"
+          }
+          Compress-Archive -Path "dist/git-smee.exe" -DestinationPath $asset -Force
+          $hash = (Get-FileHash $asset -Algorithm SHA256).Hash.ToLower()
+          "$hash  $asset" | Out-File -FilePath "$asset.sha256" -Encoding ascii
+          "asset=$asset" >> $env:GITHUB_OUTPUT
+          "checksum=$asset.sha256" >> $env:GITHUB_OUTPUT
+
+      - name: Upload Unix release assets
+        if: runner.os != 'Windows'
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
-          tag_name: ${{ env.TAG }}
-          files: git-smee-${{ env.TAG }}-${{ matrix.target }}.${{ matrix.archive_ext }}
+          tag_name: ${{ needs.prepare-release.outputs.tag }}
+          files: |
+            ${{ steps.package-unix.outputs.asset }}
+            ${{ steps.package-unix.outputs.checksum }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Windows release assets
+        if: runner.os == 'Windows'
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        with:
+          tag_name: ${{ needs.prepare-release.outputs.tag }}
+          files: |
+            ${{ steps.package-windows.outputs.asset }}
+            ${{ steps.package-windows.outputs.checksum }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   update-homebrew:
-    needs: build-and-release
+    needs: [prepare-release, build-and-release]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Update Homebrew Tap
-        uses: mislav/bump-homebrew-formula-action@v3
+        uses: mislav/bump-homebrew-formula-action@ccf2332299a883f6af50a1d2d41e5df7904dd769 # v4.1
         with:
           homebrew-tap: errfld/homebrew-git-smee
           formula-name: git-smee
-          tag-name: ${{ env.TAG }}
-          download-url: https://github.com/errfld/git-smee/releases/download/${{ env.TAG }}/git-smee-${{ env.TAG }}-aarch64-apple-darwin.tar.gz
+          tag-name: ${{ needs.prepare-release.outputs.tag }}
+          download-url: https://github.com/errfld/git-smee/releases/download/${{ needs.prepare-release.outputs.tag }}/git-smee-${{ needs.prepare-release.outputs.tag }}-aarch64-apple-darwin.tar.gz
         env:
           COMMITTER_TOKEN: ${{ secrets.HOMEBREW_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,11 @@ jobs:
       - id: validate
         name: Validate release tag
         shell: bash
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            raw_tag='${{ github.event.inputs.tag }}'
+            raw_tag="$INPUT_TAG"
             tag="$(printf '%s' "$raw_tag" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
           else
             tag='${{ github.ref_name }}'
@@ -149,12 +151,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - name: Update Homebrew Tap
+      - name: Update Homebrew Tap (Apple Silicon)
         uses: mislav/bump-homebrew-formula-action@ccf2332299a883f6af50a1d2d41e5df7904dd769 # v4.1
         with:
           homebrew-tap: errfld/homebrew-git-smee
           formula-name: git-smee
           tag-name: ${{ needs.prepare-release.outputs.tag }}
+          # This action can only bump a single URL field, so the tap remains
+          # Apple Silicon-specific until the formula moves to a multi-arch flow.
           download-url: https://github.com/errfld/git-smee/releases/download/${{ needs.prepare-release.outputs.tag }}/git-smee-${{ needs.prepare-release.outputs.tag }}-aarch64-apple-darwin.tar.gz
         env:
           COMMITTER_TOKEN: ${{ secrets.HOMEBREW_PAT }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ resolver = "2"
 [workspace.package]
 version = "0.0.1"
 edition = "2024"
+rust-version = "1.85"
 authors = ["Eran Riesenfeld"]
 license = "MIT"
 repository = "https://github.com/errfld/git-smee"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 [workspace.package]
 version = "0.0.1"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 authors = ["Eran Riesenfeld"]
 license = "MIT"
 repository = "https://github.com/errfld/git-smee"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ brew install git-smee
 cargo install git-smee-cli
 ```
 
+The minimum supported Rust version is `1.85.0`.
+
 ### From source
 
 ```bash
@@ -251,7 +253,21 @@ cargo test
 cargo run -p git-smee-cli -- --help
 ```
 
-GitHub Actions CI validates Linux (stable/beta/nightly) and Windows (stable) build/test compatibility.
+For local CI parity checks:
+
+```bash
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+rustup run stable cargo llvm-cov --workspace --all-features --locked --summary-only -- --skip repository::tests::
+cargo audit
+```
+
+GitHub Actions CI validates Linux (stable/beta/nightly), macOS (stable), Windows (stable), and MSRV (`1.85.0`) build/test compatibility.
+
+Release archives publish adjacent `.sha256` files. Verify downloads with:
+
+```bash
+shasum -a 256 -c git-smee-<version>-<target>.tar.gz.sha256
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ brew tap errfld/git-smee
 brew install git-smee
 ```
 
+The Homebrew tap currently publishes the Apple Silicon (`aarch64-apple-darwin`) release artifact.
+
 ### Cargo
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The Homebrew tap currently publishes the Apple Silicon (`aarch64-apple-darwin`) 
 cargo install git-smee-cli
 ```
 
-The minimum supported Rust version is `1.85.0`.
+The minimum supported Rust version is `1.88.0`.
 
 ### From source
 
@@ -263,7 +263,7 @@ rustup run stable cargo llvm-cov --workspace --all-features --locked --summary-o
 cargo audit
 ```
 
-GitHub Actions CI validates Linux (stable/beta/nightly), macOS (stable), Windows (stable), and MSRV (`1.85.0`) build/test compatibility.
+GitHub Actions CI validates Linux (stable/beta/nightly), macOS (stable), Windows (stable), and MSRV (`1.88.0`) build/test compatibility.
 
 Release archives publish adjacent `.sha256` files. Verify downloads with:
 

--- a/crates/git-smee-cli/Cargo.toml
+++ b/crates/git-smee-cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "git-smee-cli"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [[bin]]
 name = "git-smee"

--- a/crates/git-smee-core/Cargo.toml
+++ b/crates/git-smee-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "git-smee-core"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 toml = { version = "0.9" }


### PR DESCRIPTION
Fixes #95
Fixes #110
Fixes #113
Fixes #106
Fixes #105
Fixes #103
Fixes #102
Fixes #101
Fixes #99
Fixes #97
Fixes #104
Fixes #94
Fixes #93
Fixes #91
Fixes #89
Fixes #87
Fixes #75

## Summary
- add least-privilege, concurrency, timeout, lockfile, all-features, MSRV, audit, flake-detection, and workflow lint coverage to CI
- validate manual release tags, publish checksums, and ship Windows release artifacts
- pin workflow actions by immutable SHAs and document the updated contributor/release expectations

## Validation
- cargo test --workspace --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo fmt --all -- --check
- rustup run stable cargo llvm-cov --workspace --all-features --locked --summary-only --fail-under-lines 70 -- --skip repository::tests::
- cargo audit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established minimum supported Rust version at 1.85.0.

* **Documentation**
  * Added instructions for verifying release archive integrity using SHA-256 checksums.
  * Clarified CI compatibility coverage for macOS and MSRV builds.
  * Updated local development guide with comprehensive CI parity checks.

* **New Features**
  * Release artifacts now use OS-specific formats (tar.gz for Unix-like systems, zip for Windows) and include SHA-256 checksums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->