### PR TITLE
Fix executor redaction and public API edge cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +314,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,6 +358,7 @@ name = "git-smee-core"
 version = "0.0.1"
 dependencies = [
  "assert2",
+ "proptest",
  "rayon",
  "serde",
  "tempfile",
@@ -676,6 +698,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "predicates"
 version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,6 +746,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,6 +784,44 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "rayon"
@@ -798,6 +892,18 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -987,6 +1093,12 @@ name = "toml_writer"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
@@ -1195,6 +1307,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/git-smee-cli/src/main.rs
+++ b/crates/git-smee-cli/src/main.rs
@@ -74,7 +74,6 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         }
         Command::Run { hook, hook_args } => {
             repository::ensure_in_repo_root()?;
-            println!("Running hook: {hook}");
             let config = read_config_file(&config_path)?;
             let phase = config::LifeCyclePhase::from_str(&hook)?;
             executor::execute_hook_with_args(&config, phase, &hook_args)?;

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -499,6 +499,27 @@ command = "echo from-env-config"
         .success();
 }
 
+#[test]
+fn given_successful_hook_when_running_then_cli_stdout_contains_only_hook_output() {
+    let test_repo = common::TestRepo::default();
+    let command = if cfg!(windows) {
+        "echo hook-output"
+    } else {
+        "printf 'hook-output\\n'"
+    };
+    test_repo.write_config(&format!("[[pre-commit]]\ncommand = {command:?}\n"));
+
+    let mut cmd = Command::new(cargo::cargo_bin!("git-smee"));
+    cmd.current_dir(&test_repo.path)
+        .args(["run", "pre-commit"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("hook-output")
+                .and(predicate::str::contains("Running hook:").not()),
+        );
+}
+
 #[cfg(unix)]
 #[test]
 fn given_hook_args_when_running_then_command_receives_positional_args() {

--- a/crates/git-smee-core/Cargo.toml
+++ b/crates/git-smee-core/Cargo.toml
@@ -12,3 +12,4 @@ rayon = { version = "1" }
 [dev-dependencies]
 tempfile = "3"
 assert2 = { workspace = true }
+proptest = "1"

--- a/crates/git-smee-core/src/executor.rs
+++ b/crates/git-smee-core/src/executor.rs
@@ -159,8 +159,8 @@ fn redact_command(command: &str) -> String {
         .and_then(|index| tokens.get(index))
         .cloned()
         .unwrap_or_else(|| "<redacted>".to_string());
-    if redacted.len() > 80 {
-        redacted.truncate(77);
+    if redacted.chars().count() > 80 {
+        redacted = redacted.chars().take(77).collect();
         redacted.push_str("...");
     }
     if let Some(index) = executable_index
@@ -194,17 +194,17 @@ fn tokenize_command(command: &str) -> Vec<String> {
     let mut current = String::new();
     let mut in_single_quotes = false;
     let mut in_double_quotes = false;
-    let mut escaped = false;
+    let mut chars = command.chars().peekable();
 
-    for ch in command.chars() {
-        if escaped {
-            current.push(ch);
-            escaped = false;
-            continue;
-        }
+    while let Some(ch) = chars.next() {
         match ch {
             '\\' if !in_single_quotes => {
-                escaped = true;
+                current.push(ch);
+                if let Some(next) = chars.peek().copied()
+                    && (next.is_whitespace() || matches!(next, '\\' | '\'' | '"'))
+                {
+                    current.push(chars.next().expect("peeked char should exist"));
+                }
             }
             '\'' if !in_double_quotes => {
                 in_single_quotes = !in_single_quotes;
@@ -221,9 +221,6 @@ fn tokenize_command(command: &str) -> Vec<String> {
         }
     }
 
-    if escaped {
-        current.push('\\');
-    }
     if !current.is_empty() {
         tokens.push(current);
     }
@@ -240,6 +237,7 @@ mod tests {
     };
 
     use assert2::assert;
+    use proptest::prelude::*;
 
     use crate::config::HookDefinition;
 
@@ -474,6 +472,34 @@ mod tests {
     }
 
     #[test]
+    fn given_long_unicode_executable_when_redacting_then_name_is_truncated_without_panicking() {
+        let executable = "ä".repeat(120);
+        let command = format!("{executable} --flag");
+
+        let redacted = redact_command(&command);
+
+        assert_eq!(redacted, format!("{}... <args redacted>", "ä".repeat(77)));
+    }
+
+    #[test]
+    fn given_windows_style_path_when_redacting_then_backslashes_are_preserved() {
+        let redacted =
+            redact_command(r#""C:\Program Files\Git\bin\bash.exe" -lc "echo secret-value""#);
+
+        assert_eq!(
+            redacted,
+            r#"C:\Program Files\Git\bin\bash.exe <args redacted>"#
+        );
+    }
+
+    #[test]
+    fn given_escaped_spaces_when_redacting_then_backslashes_are_preserved() {
+        let redacted = redact_command(r#"./path\ with\ spaces/tool --token secret-value"#);
+
+        assert_eq!(redacted, r#"./path\ with\ spaces/tool <args redacted>"#);
+    }
+
+    #[test]
     fn given_empty_command_when_executing_then_no_command_defined_error() {
         let runner = FakeRunner::with_default_outcomes(vec![]);
         let result = execute_command("   ", &runner, &[]);
@@ -624,5 +650,28 @@ mod tests {
         assert!(matches!(result, Err(Error::ExecutionFailed(23))));
         assert_eq!(calls[0], "sequential");
         assert!(calls.iter().any(|call| call == "parallel-fail"));
+    }
+
+    proptest! {
+        #[test]
+        fn redact_command_never_panics_for_arbitrary_input(command in any::<String>()) {
+            let _ = redact_command(&command);
+        }
+
+        #[test]
+        fn redact_command_hides_inline_env_secret_values(
+            key in "[A-Z_][A-Z0-9_]{0,7}",
+            secret_segments in prop::collection::vec("[qxz]{3,8}", 1..4),
+            executable_suffix in "[A-Z0-9_./:\\\\-]{1,24}"
+        ) {
+            let secret = secret_segments.join(" ");
+            let executable = format!("CMD_{executable_suffix}");
+            let command = format!(r#"{key}="{secret}" {executable} --flag trailing"#);
+
+            let redacted = redact_command(&command);
+
+            prop_assert!(!redacted.contains(&secret));
+            prop_assert!(redacted.ends_with(" <args redacted>"));
+        }
     }
 }

--- a/crates/git-smee-core/src/installer.rs
+++ b/crates/git-smee-core/src/installer.rs
@@ -15,6 +15,7 @@ pub const MANAGED_FILE_MARKER: &str = "THIS FILE IS MANAGED BY git-smee";
 /// so script executability is preserved.
 pub fn with_managed_header(content: &str) -> String {
     with_managed_header_with_prefix(content, "#")
+        .expect("default managed header prefix should always be supported")
 }
 
 /// Prefixes content with a managed marker using the provided comment prefix.
@@ -23,22 +24,26 @@ pub fn with_managed_header(content: &str) -> String {
 /// so script executability is preserved.
 ///
 /// Supported prefixes are `#` (Unix-style) and `REM` (Windows batch).
-pub fn with_managed_header_with_prefix(content: &str, comment_prefix: &str) -> String {
-    assert!(
-        matches!(comment_prefix, "#" | "REM"),
-        "unsupported managed header prefix: {comment_prefix}"
-    );
+pub fn with_managed_header_with_prefix(
+    content: &str,
+    comment_prefix: &str,
+) -> Result<String, Error> {
+    if !matches!(comment_prefix, "#" | "REM") {
+        return Err(Error::UnsupportedManagedHeaderPrefix {
+            prefix: comment_prefix.to_string(),
+        });
+    }
     let marker_line = format!("{comment_prefix} {MANAGED_FILE_MARKER}");
     if content.starts_with("#!") {
         if let Some(shebang_end) = content.find('\n') {
             let (shebang, rest) = content.split_at(shebang_end + 1);
-            return format!("{shebang}{marker_line}\n\n{rest}");
+            return Ok(format!("{shebang}{marker_line}\n\n{rest}"));
         }
 
-        return format!("{content}\n{marker_line}\n\n");
+        return Ok(format!("{content}\n{marker_line}\n\n"));
     }
 
-    format!("{marker_line}\n\n{content}")
+    Ok(format!("{marker_line}\n\n{content}"))
 }
 
 #[derive(Debug, Error)]
@@ -92,6 +97,8 @@ pub enum Error {
     },
     #[error("Failed to resolve current executable path: {0}")]
     FailedToResolveCurrentExecutable(std::io::Error),
+    #[error("Unsupported managed header prefix '{prefix}'. Expected '#' or 'REM'.")]
+    UnsupportedManagedHeaderPrefix { prefix: String },
 }
 
 /// Behavioral definition of a hook installer.
@@ -609,15 +616,19 @@ mod tests {
     #[test]
     fn given_custom_prefix_when_adding_managed_header_then_prefix_is_used() {
         let config = "[[pre-commit]]\ncommand = \"cargo test\"";
-        let managed = with_managed_header_with_prefix(config, "REM");
+        let managed = with_managed_header_with_prefix(config, "REM").unwrap();
 
         assert!(managed.starts_with("REM THIS FILE IS MANAGED BY git-smee"));
     }
 
     #[test]
-    #[should_panic(expected = "unsupported managed header prefix")]
-    fn given_unsupported_prefix_when_adding_managed_header_then_it_panics() {
-        let _ = with_managed_header_with_prefix("echo test", "//");
+    fn given_unsupported_prefix_when_adding_managed_header_then_it_returns_error() {
+        let result = with_managed_header_with_prefix("echo test", "//");
+
+        assert!(matches!(
+            result,
+            Err(Error::UnsupportedManagedHeaderPrefix { prefix }) if prefix == "//"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- make command redaction UTF-8 safe and preserve backslashes for Windows/path-heavy commands
- remove non-essential `run` stdout noise and replace the panic-prone managed-header API with a typed error
- add property-based and regression tests covering redaction safety and CLI output behavior

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace

Closes #86
Closes #88
Closes #90
Closes #92
Closes #115
