### PR TITLE
Harden installer detection and hook metadata checks

### DIFF
--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -692,6 +692,36 @@ command = "true"
         .success();
 }
 
+#[cfg(unix)]
+#[test]
+fn given_special_character_config_path_when_running_installed_hook_then_wrapper_executes() {
+    let test_repo = common::TestRepo::default();
+    fs::remove_file(test_repo.config_path()).expect("failed to remove default config");
+    let custom_config = test_repo.write_config_at(
+        "configs/it's 100% ready/hook config.toml",
+        r#"
+[[pre-commit]]
+command = "true"
+"#,
+    );
+
+    let mut install = Command::new(cargo::cargo_bin!("git-smee"));
+    install
+        .current_dir(&test_repo.path)
+        .arg("--config")
+        .arg(&custom_config)
+        .arg("install")
+        .assert()
+        .success();
+
+    let hook_path = test_repo.path.join(".git/hooks/pre-commit");
+    let mut hook = Command::new(hook_path);
+    hook.current_dir(&test_repo.path)
+        .env("PATH", "/usr/bin:/bin")
+        .assert()
+        .success();
+}
+
 #[test]
 fn given_custom_config_path_when_initializing_then_init_writes_requested_file() {
     let test_repo = common::TestRepo::default();

--- a/crates/git-smee-core/src/config.rs
+++ b/crates/git-smee-core/src/config.rs
@@ -126,7 +126,7 @@ pub struct HookDefinition {
     pub parallel_execution_allowed: bool,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Debug, Clone, Copy)]
 #[serde(rename_all = "kebab-case")]
 pub enum LifeCyclePhase {
     ApplypatchMsg,
@@ -154,42 +154,39 @@ pub enum LifeCyclePhase {
     PostIndexChange,
 }
 
-impl FromStr for LifeCyclePhase {
-    type Err = crate::Error;
+const ALL_LIFECYCLE_PHASES: [LifeCyclePhase; 23] = [
+    LifeCyclePhase::ApplypatchMsg,
+    LifeCyclePhase::PreApplypatch,
+    LifeCyclePhase::PostApplypatch,
+    LifeCyclePhase::PreCommit,
+    LifeCyclePhase::PrepareCommitMsg,
+    LifeCyclePhase::CommitMsg,
+    LifeCyclePhase::PostCommit,
+    LifeCyclePhase::PreMergeCommit,
+    LifeCyclePhase::PreRebase,
+    LifeCyclePhase::PostCheckout,
+    LifeCyclePhase::PostMerge,
+    LifeCyclePhase::PostRewrite,
+    LifeCyclePhase::PrePush,
+    LifeCyclePhase::PreReceive,
+    LifeCyclePhase::Update,
+    LifeCyclePhase::ProcReceive,
+    LifeCyclePhase::PostReceive,
+    LifeCyclePhase::ReferenceTransaction,
+    LifeCyclePhase::PushToCheckout,
+    LifeCyclePhase::PreAutoGc,
+    LifeCyclePhase::PostUpdate,
+    LifeCyclePhase::FsmonitorWatchman,
+    LifeCyclePhase::PostIndexChange,
+];
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "applypatch-msg" => Ok(LifeCyclePhase::ApplypatchMsg),
-            "pre-applypatch" => Ok(LifeCyclePhase::PreApplypatch),
-            "post-applypatch" => Ok(LifeCyclePhase::PostApplypatch),
-            "pre-commit" => Ok(LifeCyclePhase::PreCommit),
-            "prepare-commit-msg" => Ok(LifeCyclePhase::PrepareCommitMsg),
-            "commit-msg" => Ok(LifeCyclePhase::CommitMsg),
-            "post-commit" => Ok(LifeCyclePhase::PostCommit),
-            "pre-merge-commit" => Ok(LifeCyclePhase::PreMergeCommit),
-            "pre-rebase" => Ok(LifeCyclePhase::PreRebase),
-            "post-checkout" => Ok(LifeCyclePhase::PostCheckout),
-            "post-merge" => Ok(LifeCyclePhase::PostMerge),
-            "post-rewrite" => Ok(LifeCyclePhase::PostRewrite),
-            "pre-push" => Ok(LifeCyclePhase::PrePush),
-            "pre-receive" => Ok(LifeCyclePhase::PreReceive),
-            "update" => Ok(LifeCyclePhase::Update),
-            "proc-receive" => Ok(LifeCyclePhase::ProcReceive),
-            "post-receive" => Ok(LifeCyclePhase::PostReceive),
-            "reference-transaction" => Ok(LifeCyclePhase::ReferenceTransaction),
-            "push-to-checkout" => Ok(LifeCyclePhase::PushToCheckout),
-            "pre-auto-gc" => Ok(LifeCyclePhase::PreAutoGc),
-            "post-update" => Ok(LifeCyclePhase::PostUpdate),
-            "fsmonitor-watchman" => Ok(LifeCyclePhase::FsmonitorWatchman),
-            "post-index-change" => Ok(LifeCyclePhase::PostIndexChange),
-            _ => Err(Error::UnknownLifeCyclePhase(s.to_string())),
-        }
+impl LifeCyclePhase {
+    pub const fn all() -> &'static [LifeCyclePhase] {
+        &ALL_LIFECYCLE_PHASES
     }
-}
 
-impl fmt::Display for LifeCyclePhase {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = match self {
+    pub const fn as_str(self) -> &'static str {
+        match self {
             LifeCyclePhase::ApplypatchMsg => "applypatch-msg",
             LifeCyclePhase::PreApplypatch => "pre-applypatch",
             LifeCyclePhase::PostApplypatch => "post-applypatch",
@@ -213,8 +210,25 @@ impl fmt::Display for LifeCyclePhase {
             LifeCyclePhase::PostUpdate => "post-update",
             LifeCyclePhase::FsmonitorWatchman => "fsmonitor-watchman",
             LifeCyclePhase::PostIndexChange => "post-index-change",
-        };
-        f.write_str(s)
+        }
+    }
+}
+
+impl FromStr for LifeCyclePhase {
+    type Err = crate::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::all()
+            .iter()
+            .copied()
+            .find(|phase| phase.as_str() == s)
+            .ok_or_else(|| Error::UnknownLifeCyclePhase(s.to_string()))
+    }
+}
+
+impl fmt::Display for LifeCyclePhase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 
@@ -363,36 +377,48 @@ mod tests {
 
     #[test]
     fn given_lifecycle_when_from_str_then_correct_enum_returned() {
-        let all_enums = [
-            LifeCyclePhase::ApplypatchMsg,
-            LifeCyclePhase::PreApplypatch,
-            LifeCyclePhase::PostApplypatch,
-            LifeCyclePhase::PreCommit,
-            LifeCyclePhase::PrepareCommitMsg,
-            LifeCyclePhase::CommitMsg,
-            LifeCyclePhase::PostCommit,
-            LifeCyclePhase::PreMergeCommit,
-            LifeCyclePhase::PreRebase,
-            LifeCyclePhase::PostCheckout,
-            LifeCyclePhase::PostMerge,
-            LifeCyclePhase::PostRewrite,
-            LifeCyclePhase::PrePush,
-            LifeCyclePhase::PreReceive,
-            LifeCyclePhase::Update,
-            LifeCyclePhase::ProcReceive,
-            LifeCyclePhase::PostReceive,
-            LifeCyclePhase::ReferenceTransaction,
-            LifeCyclePhase::PushToCheckout,
-            LifeCyclePhase::PreAutoGc,
-            LifeCyclePhase::PostUpdate,
-            LifeCyclePhase::FsmonitorWatchman,
-            LifeCyclePhase::PostIndexChange,
-        ];
-        all_enums.iter().for_each(|phase| {
+        LifeCyclePhase::all().iter().for_each(|phase| {
             let phase_str = phase.to_string();
             let parsed_phase = LifeCyclePhase::from_str(&phase_str).unwrap();
             assert_eq!(&parsed_phase, phase);
         });
+    }
+
+    #[test]
+    fn given_supported_hooks_table_when_checking_readme_then_it_matches_runtime_supported_hooks() {
+        let readme_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("README.md");
+        let readme = fs::read_to_string(readme_path).unwrap();
+        let table = readme
+            .split("### Supported Git Hooks")
+            .nth(1)
+            .and_then(|section| section.split("### Hook argument forwarding").next())
+            .expect("README supported hooks section should exist");
+        let documented_hooks: Vec<String> = table
+            .lines()
+            .filter_map(|line| {
+                let trimmed = line.trim();
+                if !trimmed.starts_with('|')
+                    || trimmed.starts_with("| Hook")
+                    || trimmed.starts_with("|------")
+                {
+                    return None;
+                }
+                trimmed
+                    .split('|')
+                    .nth(1)
+                    .map(str::trim)
+                    .filter(|hook| !hook.is_empty())
+                    .map(|hook| hook.trim_matches('`').to_owned())
+            })
+            .collect();
+        let runtime_hooks: Vec<String> = LifeCyclePhase::all()
+            .iter()
+            .map(|phase| phase.to_string())
+            .collect();
+
+        assert_eq!(documented_hooks, runtime_hooks);
     }
 
     #[test]

--- a/crates/git-smee-core/src/installer.rs
+++ b/crates/git-smee-core/src/installer.rs
@@ -8,6 +8,8 @@ use thiserror::Error;
 
 /// Marker string used to identify files managed by git-smee.
 pub const MANAGED_FILE_MARKER: &str = "THIS FILE IS MANAGED BY git-smee";
+const MANAGED_FILE_SCAN_BYTES: usize = 8 * 1024;
+const MANAGED_FILE_SCAN_LINES: usize = 32;
 
 /// Prefixes content with a managed marker using `#` comments.
 ///
@@ -289,7 +291,7 @@ impl FileSystemHookInstaller {
             path: path.to_string_lossy().to_string(),
             source,
         })?;
-        let mut header_buf = [0_u8; 1024];
+        let mut header_buf = [0_u8; MANAGED_FILE_SCAN_BYTES];
         let bytes_read =
             file.read(&mut header_buf)
                 .map_err(|source| Error::FailedToReadExistingFile {
@@ -300,8 +302,14 @@ impl FileSystemHookInstaller {
         let marker_hash = format!("# {MANAGED_FILE_MARKER}");
         let marker_rem = format!("REM {MANAGED_FILE_MARKER}");
 
-        for line in header.split(|byte| *byte == b'\n').take(8) {
-            let normalized_line = line.strip_suffix(b"\r").unwrap_or(line);
+        for line in header
+            .split(|byte| *byte == b'\n')
+            .take(MANAGED_FILE_SCAN_LINES)
+        {
+            let normalized_line = line.strip_prefix(&[0xEF, 0xBB, 0xBF]).unwrap_or(line);
+            let normalized_line = normalized_line
+                .strip_suffix(b"\r")
+                .unwrap_or(normalized_line);
             if normalized_line.is_empty() {
                 continue;
             }
@@ -398,9 +406,10 @@ pub fn install_hooks_with_options<T: HookInstaller>(
         Platform::Unix => shell_single_quote(&options.config_path),
         Platform::Windows => cmd_escape(&options.config_path),
     };
-    config
-        .hooks
-        .keys()
+    let mut phases: Vec<_> = config.hooks.keys().copied().collect();
+    phases.sort_by_key(|phase| phase.as_str());
+    phases
+        .into_iter()
         .map(|life_cycle_phase| {
             let lifecycle_phase_kebap = life_cycle_phase.to_string();
             let content = platform
@@ -431,25 +440,34 @@ fn cmd_escape(path: &Path) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicU8, Ordering};
+    use std::sync::{
+        Mutex,
+        atomic::{AtomicU8, Ordering},
+    };
 
     use super::*;
 
     struct AssertingHookInstaller {
-        assertion: fn(hook_name: &str, hook_content: &str) -> (),
+        assertion: fn(hook_name: &str, hook_content: &str),
         number_of_installed_hooks: AtomicU8,
         number_of_installed_config_files: AtomicU8,
         temp_dir: tempfile::TempDir,
+        installed_hook_names: Mutex<Vec<String>>,
     }
 
     impl AssertingHookInstaller {
-        fn new(assertion: fn(hook_name: &str, hook_content: &str) -> ()) -> Self {
+        fn new(assertion: fn(hook_name: &str, hook_content: &str)) -> Self {
             Self {
                 assertion,
                 number_of_installed_hooks: AtomicU8::new(0),
                 number_of_installed_config_files: AtomicU8::new(0),
                 temp_dir: tempfile::tempdir().unwrap(),
+                installed_hook_names: Mutex::new(Vec::new()),
             }
+        }
+
+        fn installed_hook_names(&self) -> Vec<String> {
+            self.installed_hook_names.lock().unwrap().clone()
         }
     }
 
@@ -458,6 +476,10 @@ mod tests {
             (self.assertion)(hook_name, hook_content);
             self.number_of_installed_hooks
                 .fetch_add(1, Ordering::SeqCst);
+            self.installed_hook_names
+                .lock()
+                .unwrap()
+                .push(hook_name.to_string());
             let hook = self.temp_dir.path().join(hook_name);
             fs::write(&hook, hook_content).unwrap();
             Ok(hook)
@@ -560,6 +582,54 @@ mod tests {
         assert_eq!(
             installer.number_of_installed_hooks.load(Ordering::SeqCst),
             2
+        );
+        assert_eq!(
+            installer.installed_hook_names(),
+            vec!["pre-commit".to_string(), "pre-push".to_string()]
+        );
+    }
+
+    #[test]
+    fn given_unsorted_hooks_when_installing_then_install_order_is_deterministic() {
+        let mut hooks_map = std::collections::HashMap::new();
+        hooks_map.insert(
+            crate::config::LifeCyclePhase::PrePush,
+            vec![crate::config::HookDefinition {
+                command: "echo Pre-push hook".to_string(),
+                parallel_execution_allowed: false,
+            }],
+        );
+        hooks_map.insert(
+            crate::config::LifeCyclePhase::ApplypatchMsg,
+            vec![crate::config::HookDefinition {
+                command: "echo Applypatch hook".to_string(),
+                parallel_execution_allowed: false,
+            }],
+        );
+        hooks_map.insert(
+            crate::config::LifeCyclePhase::PreCommit,
+            vec![crate::config::HookDefinition {
+                command: "echo Pre-commit hook".to_string(),
+                parallel_execution_allowed: false,
+            }],
+        );
+        let config = SmeeConfig { hooks: hooks_map };
+        let options = HookScriptOptions::new(
+            PathBuf::from("/tmp/git-smee-bin"),
+            PathBuf::from("/tmp/custom-config.toml"),
+        );
+        let installer = AssertingHookInstaller::new(|_, _| {});
+
+        let result = install_hooks_with_options(&config, &installer, &options);
+
+        assert!(result.is_ok());
+        assert_eq!(
+            installer.installed_hook_names(),
+            vec![
+                "applypatch-msg".to_string(),
+                "pre-commit".to_string(),
+                "pre-push".to_string(),
+            ]
         );
     }
 

--- a/crates/git-smee-core/tests/installer_integration.rs
+++ b/crates/git-smee-core/tests/installer_integration.rs
@@ -206,6 +206,72 @@ fn given_managed_marker_after_shebang_and_blank_line_when_installing_then_it_is_
 }
 
 #[test]
+fn given_bom_prefixed_managed_hook_when_installing_without_force_then_it_is_overwritten() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repo = temp_dir.path().join("repo");
+    init_repo(&repo);
+    write_config_fixture(&repo);
+
+    let hooks_path = resolve_hooks_path_with_git(&repo);
+    let pre_commit = hooks_path.join("pre-commit");
+    let managed_with_bom =
+        format!("\u{FEFF}#!/usr/bin/env sh\n# {MANAGED_FILE_MARKER}\necho 'stale managed hook'\n");
+    fs::write(&pre_commit, managed_with_bom).unwrap();
+
+    let config = read_config_from_repo(&repo);
+    let installer = FileSystemHookInstaller::from_path(repo.clone()).unwrap();
+    installer::install_hooks(&config, &installer).unwrap();
+
+    let installed = fs::read_to_string(pre_commit).unwrap();
+    assert!(installed.contains("run pre-commit"));
+}
+
+#[test]
+fn given_bom_prefixed_managed_config_when_initializing_without_force_then_refuses_managed_overwrite()
+ {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repo = temp_dir.path().join("repo");
+    init_repo(&repo);
+
+    let config_path = repo.join(DEFAULT_CONFIG_FILE_NAME);
+    let managed_with_bom =
+        format!("\u{FEFF}# {MANAGED_FILE_MARKER}\n\n[[pre-commit]]\ncommand = \"echo custom\"\n");
+    fs::write(&config_path, managed_with_bom).unwrap();
+
+    let installer = FileSystemHookInstaller::from_path(repo.clone()).unwrap();
+    let serialized_config: String = (&SmeeConfig::default()).try_into().unwrap();
+    let result = installer.install_config_file(&serialized_config);
+
+    assert!(matches!(
+        result,
+        Err(Error::RefusingToOverwriteManagedConfigFile { .. })
+    ));
+}
+
+#[test]
+fn given_managed_marker_beyond_previous_short_header_when_installing_then_it_is_overwritten() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repo = temp_dir.path().join("repo");
+    init_repo(&repo);
+    write_config_fixture(&repo);
+
+    let hooks_path = resolve_hooks_path_with_git(&repo);
+    let pre_commit = hooks_path.join("pre-commit");
+    let long_header = std::iter::repeat_n("# generated preamble\n", 12).collect::<String>();
+    let managed_with_long_header = format!(
+        "#!/usr/bin/env sh\n{long_header}# {MANAGED_FILE_MARKER}\necho 'stale managed hook'\n"
+    );
+    fs::write(&pre_commit, managed_with_long_header).unwrap();
+
+    let config = read_config_from_repo(&repo);
+    let installer = FileSystemHookInstaller::from_path(repo.clone()).unwrap();
+    installer::install_hooks(&config, &installer).unwrap();
+
+    let installed = fs::read_to_string(pre_commit).unwrap();
+    assert!(installed.contains("run pre-commit"));
+}
+
+#[test]
 fn given_windows_style_managed_hook_when_installing_without_force_then_it_is_overwritten() {
     let temp_dir = tempfile::tempdir().unwrap();
     let repo = temp_dir.path().join("repo");


### PR DESCRIPTION
## Summary
- make managed-file detection robust to BOM-prefixed and longer generated headers while keeping the scan bounded
- install hooks in a deterministic lifecycle order and add a Unix end-to-end wrapper execution regression for special-character config paths
- derive parser/display behavior from a canonical hook-name list and verify the README supported-hooks table matches runtime support

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace

Closes #77
Closes #78
Closes #98
Closes #109
