### PR TITLE
Preserve stdin for multi-command hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,6 +665,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +681,7 @@ checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/README.md
+++ b/README.md
@@ -188,6 +188,11 @@ On all platforms, git-smee also exports forwarded hook args as environment varia
 - `GIT_SMEE_HOOK_ARGC`: number of forwarded args
 - `GIT_SMEE_HOOK_ARG_1` ... `GIT_SMEE_HOOK_ARG_N`: individual argument values
 
+When `git smee run` receives stdin, it buffers that payload once and replays identical bytes to
+each configured command for the hook. This keeps stdin-driven hooks such as `pre-push`,
+`pre-receive`, and `post-receive` deterministic even when multiple commands are configured for
+the same phase.
+
 ## CLI Commands
 
 ```bash

--- a/crates/git-smee-cli/Cargo.toml
+++ b/crates/git-smee-cli/Cargo.toml
@@ -16,4 +16,4 @@ assert_cmd = "2.1"
 assert_fs = "1.1"
 predicates = "3.1"
 tempfile = "3"
-git2 = "0.20"
+git2 = { version = "0.20", features = ["vendored-openssl"] }

--- a/crates/git-smee-cli/src/main.rs
+++ b/crates/git-smee-cli/src/main.rs
@@ -1,5 +1,6 @@
 use std::{
     env, fs,
+    io::{self, IsTerminal, Read},
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -76,9 +77,15 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         }
         Command::Run { hook, hook_args } => {
             repository::ensure_in_repo_root()?;
+            let stdin_payload = read_hook_stdin()?;
             let config = read_config_file(&config_path)?;
             let phase = config::LifeCyclePhase::from_str(&hook)?;
-            executor::execute_hook_with_args(&config, phase, &hook_args)?;
+            executor::execute_hook_with_args_and_stdin(
+                &config,
+                phase,
+                &hook_args,
+                stdin_payload.as_deref(),
+            )?;
             Ok(())
         }
         Command::Initialize { force } => {
@@ -120,6 +127,17 @@ fn normalize_user_config_path(path: PathBuf, invocation_dir: &Path) -> PathBuf {
     } else {
         invocation_dir.join(path)
     }
+}
+
+fn read_hook_stdin() -> io::Result<Option<Vec<u8>>> {
+    let stdin = io::stdin();
+    if stdin.is_terminal() {
+        return Ok(None);
+    }
+
+    let mut payload = Vec::new();
+    stdin.lock().read_to_end(&mut payload)?;
+    Ok(Some(payload))
 }
 
 #[cfg(unix)]

--- a/crates/git-smee-cli/src/main.rs
+++ b/crates/git-smee-cli/src/main.rs
@@ -12,6 +12,8 @@ use git_smee_core::{
     repository,
 };
 
+const MAX_HOOK_STDIN_BYTES: u64 = 10 * 1024 * 1024;
+
 #[derive(clap::Parser)]
 #[command(name = "git-smee")]
 #[command(about = "🏴‍☠️ Smee - the right hand of (Git) hooks", long_about = None)]
@@ -135,8 +137,17 @@ fn read_hook_stdin() -> io::Result<Option<Vec<u8>>> {
         return Ok(None);
     }
 
-    let mut payload = Vec::new();
-    stdin.lock().read_to_end(&mut payload)?;
+    let mut payload = Vec::with_capacity(MAX_HOOK_STDIN_BYTES as usize);
+    stdin
+        .lock()
+        .take(MAX_HOOK_STDIN_BYTES + 1)
+        .read_to_end(&mut payload)?;
+    if payload.len() as u64 > MAX_HOOK_STDIN_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("hook stdin exceeds the {MAX_HOOK_STDIN_BYTES} byte limit"),
+        ));
+    }
     Ok(Some(payload))
 }
 

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -1,12 +1,24 @@
-use std::{fs, process::Command};
+use std::{fs, path::Path};
 
+use assert_cmd::Command;
 use assert_cmd::cargo;
-use assert_cmd::prelude::*;
 use assert_fs::TempDir;
 use git_smee_core::config::LifeCyclePhase;
 use git_smee_core::installer::MANAGED_FILE_MARKER;
 use predicates::prelude::*;
 mod common;
+
+#[cfg(unix)]
+fn stdin_capture_command(output_path: &Path) -> String {
+    let escaped_path = output_path.to_string_lossy().replace('\'', "'\"'\"'");
+    format!("IFS= read -r GIT_SMEE_INPUT && printf %s \"$GIT_SMEE_INPUT\" > '{escaped_path}'")
+}
+
+#[cfg(windows)]
+fn stdin_capture_command(output_path: &Path) -> String {
+    let escaped_path = output_path.to_string_lossy().replace('"', "\"\"");
+    format!("set /p GIT_SMEE_INPUT= && > \"{escaped_path}\" <nul set /p =%GIT_SMEE_INPUT%")
+}
 
 #[test]
 fn given_git_smee_when_help_then_success() {
@@ -615,6 +627,31 @@ fn given_hook_args_when_running_then_command_receives_env_arg_contract() {
         .args(["run", "commit-msg", "alpha", "beta"])
         .assert()
         .success();
+}
+
+#[test]
+fn given_stdin_driven_hook_with_multiple_commands_when_running_then_each_command_receives_same_input()
+ {
+    let test_repo = common::TestRepo::default();
+    let first_output = test_repo.path.join("first-stdin.txt");
+    let second_output = test_repo.path.join("second-stdin.txt");
+    let first_command = stdin_capture_command(&first_output);
+    let second_command = stdin_capture_command(&second_output);
+    test_repo.write_config(&format!(
+        "[[pre-push]]\ncommand = {first_command:?}\n\n[[pre-push]]\ncommand = {second_command:?}\n"
+    ));
+
+    let stdin_payload = "refs/heads/main 123 refs/remotes/origin/main 456";
+
+    let mut cmd = Command::new(cargo::cargo_bin!("git-smee"));
+    cmd.current_dir(&test_repo.path)
+        .args(["run", "pre-push"])
+        .write_stdin(format!("{stdin_payload}\n"))
+        .assert()
+        .success();
+
+    assert_eq!(fs::read_to_string(first_output).unwrap(), stdin_payload);
+    assert_eq!(fs::read_to_string(second_output).unwrap(), stdin_payload);
 }
 
 #[test]

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -16,7 +16,9 @@ fn stdin_capture_command(output_path: &Path) -> String {
 
 #[cfg(windows)]
 fn stdin_capture_command(output_path: &Path) -> String {
-    let escaped_path = output_path.to_string_lossy().replace('"', "\"\"");
+    let path = output_path.to_string_lossy();
+    let path = path.strip_prefix(r"\\?\").unwrap_or(&path);
+    let escaped_path = path.replace('"', "\"\"");
     format!("more > \"{escaped_path}\"")
 }
 

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -18,8 +18,7 @@ fn stdin_capture_command(output_path: &Path) -> String {
 fn stdin_capture_command(output_path: &Path) -> String {
     let path = output_path.to_string_lossy();
     let path = path.strip_prefix(r"\\?\").unwrap_or(&path);
-    let escaped_path = path.replace('"', "\"\"");
-    format!(r#"findstr /R "^" > "{escaped_path}""#)
+    format!("findstr /R . > {path}")
 }
 
 #[test]

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -18,8 +18,10 @@ fn stdin_capture_command(output_path: &Path) -> String {
 fn stdin_capture_command(output_path: &Path) -> String {
     let path = output_path.to_string_lossy();
     let path = path.strip_prefix(r"\\?\").unwrap_or(&path);
-    let escaped_path = path.replace('"', "\"\"");
-    format!("more > \"{escaped_path}\"")
+    let escaped_path = path.replace('\'', "''");
+    format!(
+        "powershell -NoProfile -Command \"$inputStream=[Console]::OpenStandardInput(); $outputStream=[IO.File]::Create('{escaped_path}'); try {{ $inputStream.CopyTo($outputStream) }} finally {{ $outputStream.Dispose() }}\""
+    )
 }
 
 #[test]

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -16,10 +16,8 @@ fn stdin_capture_command(output_path: &Path) -> String {
 
 #[cfg(windows)]
 fn stdin_capture_command(output_path: &Path) -> String {
-    let escaped_path = output_path.to_string_lossy().replace('\'', "''");
-    format!(
-        "pwsh -NoProfile -NonInteractive -Command \"$data = [Console]::In.ReadToEnd(); [IO.File]::WriteAllText('{escaped_path}', $data, [System.Text.UTF8Encoding]::new($false))\""
-    )
+    let escaped_path = output_path.to_string_lossy().replace('"', "\"\"");
+    format!("more > \"{escaped_path}\"")
 }
 
 #[test]
@@ -807,8 +805,24 @@ fn given_stdin_driven_hook_with_multiple_commands_when_running_then_each_command
         .assert()
         .success();
 
-    assert_eq!(fs::read_to_string(first_output).unwrap(), stdin_payload);
-    assert_eq!(fs::read_to_string(second_output).unwrap(), stdin_payload);
+    assert_eq!(
+        normalize_test_newlines(&fs::read_to_string(first_output).unwrap()),
+        stdin_payload
+    );
+    assert_eq!(
+        normalize_test_newlines(&fs::read_to_string(second_output).unwrap()),
+        stdin_payload
+    );
+}
+
+#[cfg(windows)]
+fn normalize_test_newlines(value: &str) -> String {
+    value.replace("\r\n", "\n")
+}
+
+#[cfg(not(windows))]
+fn normalize_test_newlines(value: &str) -> String {
+    value.to_string()
 }
 
 #[test]

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -18,7 +18,7 @@ fn stdin_capture_command(output_path: &Path) -> String {
 fn stdin_capture_command(output_path: &Path) -> String {
     let escaped_path = output_path.to_string_lossy().replace('\'', "''");
     format!(
-        "powershell -NoProfile -Command \"$input = [Console]::In.ReadToEnd(); [IO.File]::WriteAllText('{escaped_path}', $input, [Text.UTF8Encoding]::new($false))\""
+        "pwsh -NoProfile -NonInteractive -Command \"$data = [Console]::In.ReadToEnd(); [IO.File]::WriteAllText('{escaped_path}', $data, [System.Text.UTF8Encoding]::new($false))\""
     )
 }
 

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -18,10 +18,8 @@ fn stdin_capture_command(output_path: &Path) -> String {
 fn stdin_capture_command(output_path: &Path) -> String {
     let path = output_path.to_string_lossy();
     let path = path.strip_prefix(r"\\?\").unwrap_or(&path);
-    let escaped_path = path.replace('\'', "''");
-    format!(
-        "powershell -NoProfile -Command \"[IO.File]::WriteAllText('{escaped_path}', [Console]::In.ReadToEnd(), (New-Object Text.UTF8Encoding $false))\""
-    )
+    let escaped_path = path.replace('"', "\"\"");
+    format!(r#"findstr /R "^" > "{escaped_path}""#)
 }
 
 #[test]

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -20,7 +20,7 @@ fn stdin_capture_command(output_path: &Path) -> String {
     let path = path.strip_prefix(r"\\?\").unwrap_or(&path);
     let escaped_path = path.replace('\'', "''");
     format!(
-        "powershell -NoProfile -Command \"$inputStream=[Console]::OpenStandardInput(); $outputStream=[IO.File]::Create('{escaped_path}'); try {{ $inputStream.CopyTo($outputStream) }} finally {{ $outputStream.Dispose() }}\""
+        "powershell -NoProfile -Command \"[IO.File]::WriteAllText('{escaped_path}', [Console]::In.ReadToEnd(), (New-Object Text.UTF8Encoding $false))\""
     )
 }
 

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -11,13 +11,15 @@ mod common;
 #[cfg(unix)]
 fn stdin_capture_command(output_path: &Path) -> String {
     let escaped_path = output_path.to_string_lossy().replace('\'', "'\"'\"'");
-    format!("IFS= read -r GIT_SMEE_INPUT && printf %s \"$GIT_SMEE_INPUT\" > '{escaped_path}'")
+    format!("cat > '{escaped_path}'")
 }
 
 #[cfg(windows)]
 fn stdin_capture_command(output_path: &Path) -> String {
-    let escaped_path = output_path.to_string_lossy().replace('"', "\"\"");
-    format!("set /p GIT_SMEE_INPUT= && > \"{escaped_path}\" <nul set /p =%GIT_SMEE_INPUT%")
+    let escaped_path = output_path.to_string_lossy().replace('\'', "''");
+    format!(
+        "powershell -NoProfile -Command \"$input = [Console]::In.ReadToEnd(); [IO.File]::WriteAllText('{escaped_path}', $input, [Text.UTF8Encoding]::new($false))\""
+    )
 }
 
 #[test]
@@ -641,12 +643,12 @@ fn given_stdin_driven_hook_with_multiple_commands_when_running_then_each_command
         "[[pre-push]]\ncommand = {first_command:?}\n\n[[pre-push]]\ncommand = {second_command:?}\n"
     ));
 
-    let stdin_payload = "refs/heads/main 123 refs/remotes/origin/main 456";
+    let stdin_payload = "refs/heads/main 123 refs/remotes/origin/main 456\nrefs/heads/feature abc refs/remotes/origin/feature def\n";
 
     let mut cmd = Command::new(cargo::cargo_bin!("git-smee"));
     cmd.current_dir(&test_repo.path)
         .args(["run", "pre-push"])
-        .write_stdin(format!("{stdin_payload}\n"))
+        .write_stdin(stdin_payload)
         .assert()
         .success();
 

--- a/crates/git-smee-core/src/executor.rs
+++ b/crates/git-smee-core/src/executor.rs
@@ -1,6 +1,7 @@
 use rayon::prelude::*;
 
 use rayon::iter::IntoParallelRefIterator;
+use std::{io::Write, process::Stdio};
 use thiserror::Error;
 
 use crate::{
@@ -28,7 +29,7 @@ pub enum Error {
 }
 
 pub fn execute_hook(smee_config: &SmeeConfig, phase: LifeCyclePhase) -> Result<(), Error> {
-    execute_hook_with_args(smee_config, phase, &[])
+    execute_hook_with_args_and_stdin(smee_config, phase, &[], None)
 }
 
 pub fn execute_hook_with_args(
@@ -36,7 +37,22 @@ pub fn execute_hook_with_args(
     phase: LifeCyclePhase,
     hook_args: &[String],
 ) -> Result<(), Error> {
-    execute_hook_with_platform_and_args(smee_config, phase, Platform::current(), hook_args)
+    execute_hook_with_args_and_stdin(smee_config, phase, hook_args, None)
+}
+
+pub fn execute_hook_with_args_and_stdin(
+    smee_config: &SmeeConfig,
+    phase: LifeCyclePhase,
+    hook_args: &[String],
+    stdin_payload: Option<&[u8]>,
+) -> Result<(), Error> {
+    execute_hook_with_platform_and_args_and_stdin(
+        smee_config,
+        phase,
+        Platform::current(),
+        hook_args,
+        stdin_payload,
+    )
 }
 
 pub fn execute_hook_with_platform(
@@ -44,7 +60,7 @@ pub fn execute_hook_with_platform(
     phase: LifeCyclePhase,
     platform: Platform,
 ) -> Result<(), Error> {
-    execute_hook_with_platform_and_args(smee_config, phase, platform, &[])
+    execute_hook_with_platform_and_args_and_stdin(smee_config, phase, platform, &[], None)
 }
 
 pub fn execute_hook_with_platform_and_args(
@@ -53,10 +69,20 @@ pub fn execute_hook_with_platform_and_args(
     platform: Platform,
     hook_args: &[String],
 ) -> Result<(), Error> {
+    execute_hook_with_platform_and_args_and_stdin(smee_config, phase, platform, hook_args, None)
+}
+
+pub fn execute_hook_with_platform_and_args_and_stdin(
+    smee_config: &SmeeConfig,
+    phase: LifeCyclePhase,
+    platform: Platform,
+    hook_args: &[String],
+    stdin_payload: Option<&[u8]>,
+) -> Result<(), Error> {
     let runner = PlatformCommandRunner {
         platform: &platform,
     };
-    execute_hook_with_runner(smee_config, phase, &runner, hook_args)
+    execute_hook_with_runner(smee_config, phase, &runner, hook_args, stdin_payload)
 }
 
 fn execute_hook_with_runner<R: CommandRunner>(
@@ -64,15 +90,21 @@ fn execute_hook_with_runner<R: CommandRunner>(
     phase: LifeCyclePhase,
     runner: &R,
     hook_args: &[String],
+    stdin_payload: Option<&[u8]>,
 ) -> Result<(), Error> {
     match smee_config.hooks.get(&phase) {
         None => Err(Error::NoHooksConfigured(phase)),
-        Some(hooks) => run_hooks_with_runner(hooks, runner, hook_args),
+        Some(hooks) => run_hooks_with_runner(hooks, runner, hook_args, stdin_payload),
     }
 }
 
 trait CommandRunner: Sync {
-    fn run(&self, command: &str, hook_args: &[String]) -> Result<Option<i32>, std::io::Error>;
+    fn run(
+        &self,
+        command: &str,
+        hook_args: &[String],
+        stdin_payload: Option<&[u8]>,
+    ) -> Result<Option<i32>, std::io::Error>;
     fn shell_display(&self) -> &'static str;
 }
 
@@ -81,7 +113,12 @@ struct PlatformCommandRunner<'a> {
 }
 
 impl CommandRunner for PlatformCommandRunner<'_> {
-    fn run(&self, command: &str, hook_args: &[String]) -> Result<Option<i32>, std::io::Error> {
+    fn run(
+        &self,
+        command: &str,
+        hook_args: &[String],
+        stdin_payload: Option<&[u8]>,
+    ) -> Result<Option<i32>, std::io::Error> {
         let mut shell_command = self.platform.create_command();
         shell_command.arg(command);
         shell_command.env("GIT_SMEE_HOOK_ARGC", hook_args.len().to_string());
@@ -95,7 +132,17 @@ impl CommandRunner for PlatformCommandRunner<'_> {
             }
             Platform::Windows => {}
         }
-        shell_command.status().map(|status| status.code())
+        if stdin_payload.is_some() {
+            shell_command.stdin(Stdio::piped());
+        }
+
+        let mut child = shell_command.spawn()?;
+        if let Some(stdin_payload) = stdin_payload
+            && let Some(mut stdin) = child.stdin.take()
+        {
+            stdin.write_all(stdin_payload)?;
+        }
+        child.wait().map(|status| status.code())
     }
 
     fn shell_display(&self) -> &'static str {
@@ -107,6 +154,7 @@ fn run_hooks_with_runner<R: CommandRunner>(
     hooks: &[HookDefinition],
     runner: &R,
     hook_args: &[String],
+    stdin_payload: Option<&[u8]>,
 ) -> Result<(), Error> {
     let (parallel_hooks, sequential_hooks): (Vec<&HookDefinition>, Vec<&HookDefinition>) = (
         hooks
@@ -121,10 +169,10 @@ fn run_hooks_with_runner<R: CommandRunner>(
 
     sequential_hooks
         .iter()
-        .try_for_each(|&hook| execute_command(&hook.command, runner, hook_args))?;
+        .try_for_each(|&hook| execute_command(&hook.command, runner, hook_args, stdin_payload))?;
     parallel_hooks
         .par_iter()
-        .try_for_each(|&hook| execute_command(&hook.command, runner, hook_args))?;
+        .try_for_each(|&hook| execute_command(&hook.command, runner, hook_args, stdin_payload))?;
     Ok(())
 }
 
@@ -132,12 +180,13 @@ fn execute_command(
     command: &str,
     runner: &impl CommandRunner,
     hook_args: &[String],
+    stdin_payload: Option<&[u8]>,
 ) -> Result<(), Error> {
     if command.trim().is_empty() {
         return Err(Error::NoCommandDefined);
     }
     let exit_code = runner
-        .run(command, hook_args)
+        .run(command, hook_args, stdin_payload)
         .map_err(|source| Error::CommandSpawnFailed {
             command: redact_command(command),
             shell: runner.shell_display().to_string(),
@@ -254,6 +303,7 @@ mod tests {
         default_outcomes: VecDeque<PlannedResult>,
         calls: Vec<String>,
         hook_args_calls: Vec<Vec<String>>,
+        stdin_calls: Vec<Option<Vec<u8>>>,
     }
 
     struct FakeRunner {
@@ -292,13 +342,23 @@ mod tests {
         fn hook_args_calls(&self) -> Vec<Vec<String>> {
             self.state.lock().unwrap().hook_args_calls.clone()
         }
+
+        fn stdin_calls(&self) -> Vec<Option<Vec<u8>>> {
+            self.state.lock().unwrap().stdin_calls.clone()
+        }
     }
 
     impl CommandRunner for FakeRunner {
-        fn run(&self, command: &str, hook_args: &[String]) -> Result<Option<i32>, io::Error> {
+        fn run(
+            &self,
+            command: &str,
+            hook_args: &[String],
+            stdin_payload: Option<&[u8]>,
+        ) -> Result<Option<i32>, io::Error> {
             let mut state = self.state.lock().unwrap();
             state.calls.push(command.to_string());
             state.hook_args_calls.push(hook_args.to_vec());
+            state.stdin_calls.push(stdin_payload.map(Vec::from));
             let outcome = state
                 .outcomes_by_command
                 .get_mut(command)
@@ -342,7 +402,8 @@ mod tests {
         let config = SmeeConfig { hooks: hooks_map };
         let runner = FakeRunner::with_default_outcomes(vec![PlannedResult::Exit(Some(0))]);
 
-        let result = execute_hook_with_runner(&config, LifeCyclePhase::PreCommit, &runner, &[]);
+        let result =
+            execute_hook_with_runner(&config, LifeCyclePhase::PreCommit, &runner, &[], None);
         assert!(result.is_ok());
         assert_eq!(runner.calls(), vec!["run-pre-commit"]);
     }
@@ -361,12 +422,44 @@ mod tests {
         let runner = FakeRunner::with_default_outcomes(vec![PlannedResult::Exit(Some(0))]);
         let hook_args = vec!["COMMIT_EDITMSG".to_string(), "message".to_string()];
 
-        let result =
-            execute_hook_with_runner(&config, LifeCyclePhase::CommitMsg, &runner, &hook_args);
+        let result = execute_hook_with_runner(
+            &config,
+            LifeCyclePhase::CommitMsg,
+            &runner,
+            &hook_args,
+            None,
+        );
 
         assert!(result.is_ok());
         assert_eq!(runner.calls(), vec!["check-commit-message"]);
         assert_eq!(runner.hook_args_calls(), vec![hook_args]);
+    }
+
+    #[test]
+    fn given_stdin_payload_when_executing_then_each_command_receives_the_same_bytes() {
+        let hooks = vec![
+            HookDefinition {
+                command: "first".to_string(),
+                parallel_execution_allowed: false,
+            },
+            HookDefinition {
+                command: "second".to_string(),
+                parallel_execution_allowed: false,
+            },
+        ];
+        let runner = FakeRunner::with_command_outcomes(vec![
+            ("first", vec![PlannedResult::Exit(Some(0))]),
+            ("second", vec![PlannedResult::Exit(Some(0))]),
+        ]);
+        let stdin_payload = b"refs/heads/main 0123456789 refs/heads/main abcdef0123\n";
+
+        let result = run_hooks_with_runner(&hooks, &runner, &[], Some(stdin_payload));
+
+        assert!(result.is_ok());
+        assert_eq!(
+            runner.stdin_calls(),
+            vec![Some(stdin_payload.to_vec()), Some(stdin_payload.to_vec()),]
+        );
     }
 
     #[test]
@@ -382,7 +475,8 @@ mod tests {
         let config = SmeeConfig { hooks: hooks_map };
         let runner = FakeRunner::with_default_outcomes(vec![PlannedResult::Exit(Some(127))]);
 
-        let result = execute_hook_with_runner(&config, LifeCyclePhase::PreCommit, &runner, &[]);
+        let result =
+            execute_hook_with_runner(&config, LifeCyclePhase::PreCommit, &runner, &[], None);
         assert!(matches!(result, Err(Error::ExecutionFailed(127))));
     }
 
@@ -393,7 +487,7 @@ mod tests {
             io::ErrorKind::NotFound,
         )]);
 
-        let result = execute_command("deploy --token super-secret-value", &runner, &[]);
+        let result = execute_command("deploy --token super-secret-value", &runner, &[], None);
 
         match result {
             Err(Error::CommandSpawnFailed {
@@ -419,6 +513,7 @@ mod tests {
             "TOKEN=super-secret API_KEY=123 deploy --arg value",
             &runner,
             &[],
+            None,
         );
 
         match result {
@@ -442,6 +537,7 @@ mod tests {
             "TOKEN=\"super secret\" API_KEY='another secret' ./deploy --arg value",
             &runner,
             &[],
+            None,
         );
 
         match result {
@@ -502,14 +598,14 @@ mod tests {
     #[test]
     fn given_empty_command_when_executing_then_no_command_defined_error() {
         let runner = FakeRunner::with_default_outcomes(vec![]);
-        let result = execute_command("   ", &runner, &[]);
+        let result = execute_command("   ", &runner, &[], None);
         assert!(matches!(result, Err(Error::NoCommandDefined)));
     }
 
     #[test]
     fn given_missing_exit_code_when_executing_then_terminated_by_signal_error() {
         let runner = FakeRunner::with_default_outcomes(vec![PlannedResult::Exit(None)]);
-        let result = execute_command("run-hook", &runner, &[]);
+        let result = execute_command("run-hook", &runner, &[], None);
         assert!(matches!(result, Err(Error::ExecutionTerminatedBySignal)));
     }
 
@@ -534,7 +630,8 @@ mod tests {
             ("parallel-4", vec![PlannedResult::Exit(Some(0))]),
         ]);
 
-        let result = execute_hook_with_runner(&config, LifeCyclePhase::PreCommit, &runner, &[]);
+        let result =
+            execute_hook_with_runner(&config, LifeCyclePhase::PreCommit, &runner, &[], None);
 
         assert!(result.is_ok());
         let mut calls = runner.calls();
@@ -579,7 +676,8 @@ mod tests {
             ("parallel-3", vec![PlannedResult::Exit(Some(0))]),
         ]);
 
-        let result = execute_hook_with_runner(&config, LifeCyclePhase::PreCommit, &runner, &[]);
+        let result =
+            execute_hook_with_runner(&config, LifeCyclePhase::PreCommit, &runner, &[], None);
         let calls = runner.calls();
 
         assert!(result.is_ok());
@@ -616,7 +714,7 @@ mod tests {
             ("parallel", vec![PlannedResult::Exit(Some(0))]),
         ]);
 
-        let result = run_hooks_with_runner(&hooks, &runner, &[]);
+        let result = run_hooks_with_runner(&hooks, &runner, &[], None);
 
         assert!(matches!(result, Err(Error::ExecutionFailed(10))));
         assert_eq!(runner.calls(), vec!["sequential"]);
@@ -644,7 +742,7 @@ mod tests {
             ("parallel-fail", vec![PlannedResult::Exit(Some(23))]),
         ]);
 
-        let result = run_hooks_with_runner(&hooks, &runner, &[]);
+        let result = run_hooks_with_runner(&hooks, &runner, &[], None);
         let calls = runner.calls();
 
         assert!(matches!(result, Err(Error::ExecutionFailed(23))));

--- a/crates/git-smee-core/src/executor.rs
+++ b/crates/git-smee-core/src/executor.rs
@@ -1,5 +1,8 @@
 use std::{env, io::Write, process::Stdio};
 
+#[cfg(windows)]
+use std::path::PathBuf;
+
 use rayon::iter::IntoParallelRefIterator;
 use rayon::prelude::*;
 use thiserror::Error;
@@ -133,6 +136,11 @@ impl CommandRunner for PlatformCommandRunner<'_> {
             shell_command.stdin(Stdio::piped());
         }
 
+        #[cfg(windows)]
+        if let Some(current_dir) = cmd_compatible_current_dir()? {
+            shell_command.current_dir(current_dir);
+        }
+
         let mut child = shell_command.spawn()?;
         let stdin_result = if let Some(stdin_payload) = stdin_payload {
             if let Some(mut stdin) = child.stdin.take() {
@@ -167,6 +175,13 @@ fn apply_hook_arg_env(shell_command: &mut std::process::Command, hook_args: &[St
     for (index, arg) in hook_args.iter().enumerate() {
         shell_command.env(format!("GIT_SMEE_HOOK_ARG_{}", index + 1), arg);
     }
+}
+
+#[cfg(windows)]
+fn cmd_compatible_current_dir() -> Result<Option<PathBuf>, std::io::Error> {
+    let current_dir = env::current_dir()?;
+    let current_dir = current_dir.to_string_lossy();
+    Ok(current_dir.strip_prefix(r"\\?\").map(PathBuf::from))
 }
 
 fn is_hook_arg_env_key(key: &str) -> bool {

--- a/crates/git-smee-core/src/executor.rs
+++ b/crates/git-smee-core/src/executor.rs
@@ -137,12 +137,18 @@ impl CommandRunner for PlatformCommandRunner<'_> {
         }
 
         let mut child = shell_command.spawn()?;
-        if let Some(stdin_payload) = stdin_payload
-            && let Some(mut stdin) = child.stdin.take()
-        {
-            stdin.write_all(stdin_payload)?;
-        }
-        child.wait().map(|status| status.code())
+        let stdin_result = if let Some(stdin_payload) = stdin_payload {
+            if let Some(mut stdin) = child.stdin.take() {
+                stdin.write_all(stdin_payload)
+            } else {
+                Ok(())
+            }
+        } else {
+            Ok(())
+        };
+        let wait_result = child.wait().map(|status| status.code());
+        stdin_result?;
+        wait_result
     }
 
     fn shell_display(&self) -> &'static str {


### PR DESCRIPTION
Fixes #74

## Summary
- buffer non-terminal stdin once at `git smee run` entry so interactive invocations do not block on terminal reads
- replay the captured stdin payload to every configured hook command while preserving existing hook-arg forwarding
- add executor and CLI regressions covering multi-command stdin replay and document the stdin contract in the README

## Validation
- `cargo fmt --all -- --check`
- `cargo test --workspace --all-features --locked -- --skip repository::tests::`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced hook execution to capture non-interactive stdin once and replay the identical input to every configured command within the same hook phase, ensuring deterministic results in multi-command scenarios.

* **Documentation**
  * Updated documentation to describe stdin buffering/replay behavior for stdin-driven hooks.

* **Tests**
  * Added an integration test verifying that multiple commands for the same hook receive the same stdin payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->