### PR TITLE
Fix hook arg env cleanup and init config validation

### DIFF
--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -1059,6 +1059,53 @@ fn given_managed_custom_config_when_init_without_force_then_it_refuses_to_overwr
 }
 
 #[test]
+fn given_custom_config_directory_when_init_then_user_friendly_not_a_file_error() {
+    let test_repo = common::TestRepo::default();
+    fs::remove_file(test_repo.config_path()).expect("failed to remove default config");
+    let config_dir = test_repo.path.join("configs/directory-target.toml");
+    fs::create_dir_all(&config_dir).expect("failed to create config directory");
+
+    let mut cmd = Command::new(cargo::cargo_bin!("git-smee"));
+    cmd.current_dir(&test_repo.path)
+        .arg("--config")
+        .arg(&config_dir)
+        .arg("init")
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains(
+                "Error: The specified configuration path exists but is not a regular file",
+            )
+            .and(predicate::str::contains("FailedToReadExistingFile").not())
+            .and(predicate::str::contains("FailedToWriteConfigFile").not()),
+        );
+}
+
+#[test]
+fn given_custom_config_directory_when_init_with_force_then_user_friendly_not_a_file_error() {
+    let test_repo = common::TestRepo::default();
+    fs::remove_file(test_repo.config_path()).expect("failed to remove default config");
+    let config_dir = test_repo.path.join("configs/force-directory-target.toml");
+    fs::create_dir_all(&config_dir).expect("failed to create config directory");
+
+    let mut cmd = Command::new(cargo::cargo_bin!("git-smee"));
+    cmd.current_dir(&test_repo.path)
+        .arg("--config")
+        .arg(&config_dir)
+        .arg("init")
+        .arg("--force")
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains(
+                "Error: The specified configuration path exists but is not a regular file",
+            )
+            .and(predicate::str::contains("FailedToReadExistingFile").not())
+            .and(predicate::str::contains("FailedToWriteConfigFile").not()),
+        );
+}
+
+#[test]
 fn given_relative_config_flag_when_installing_from_subdir_then_cli_resolves_from_invocation_dir() {
     let test_repo = common::TestRepo::default();
     fs::remove_file(test_repo.config_path()).expect("failed to remove default config");

--- a/crates/git-smee-core/src/executor.rs
+++ b/crates/git-smee-core/src/executor.rs
@@ -130,7 +130,7 @@ fn is_hook_arg_env_key(key: &str) -> bool {
         return false;
     }
     let suffix = &key[prefix.len()..];
-    !suffix.is_empty() && suffix.chars().all(|ch| ch.is_ascii_digit())
+    !suffix.is_empty() && !suffix.starts_with('0') && suffix.chars().all(|ch| ch.is_ascii_digit())
 }
 
 fn run_hooks_with_runner<R: CommandRunner>(
@@ -497,6 +497,8 @@ mod tests {
         assert!(is_hook_arg_env_key("git_smee_hook_arg_12"));
         assert!(!is_hook_arg_env_key("GIT_SMEE_HOOK_ARG"));
         assert!(!is_hook_arg_env_key("GIT_SMEE_HOOK_ARG_"));
+        assert!(!is_hook_arg_env_key("GIT_SMEE_HOOK_ARG_0"));
+        assert!(!is_hook_arg_env_key("GIT_SMEE_HOOK_ARG_01"));
         assert!(!is_hook_arg_env_key("GIT_SMEE_HOOK_ARG_0x1"));
         assert!(!is_hook_arg_env_key("GIT_SMEE_HOOK_ARGS_FILE"));
         assert!(!is_hook_arg_env_key("GIT_SMEE_HOOK_ARGUMENT_MODE"));

--- a/crates/git-smee-core/src/executor.rs
+++ b/crates/git-smee-core/src/executor.rs
@@ -118,9 +118,19 @@ fn apply_hook_arg_env(shell_command: &mut std::process::Command, hook_args: &[St
 }
 
 fn is_hook_arg_env_key(key: &str) -> bool {
-    let prefix_len = "GIT_SMEE_HOOK_ARG".len();
-    key.get(..prefix_len)
-        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("GIT_SMEE_HOOK_ARG"))
+    if key.eq_ignore_ascii_case("GIT_SMEE_HOOK_ARGC") {
+        return true;
+    }
+
+    let prefix = "GIT_SMEE_HOOK_ARG_";
+    let Some(prefix_part) = key.get(..prefix.len()) else {
+        return false;
+    };
+    if !prefix_part.eq_ignore_ascii_case(prefix) {
+        return false;
+    }
+    let suffix = &key[prefix.len()..];
+    !suffix.is_empty() && suffix.chars().all(|ch| ch.is_ascii_digit())
 }
 
 fn run_hooks_with_runner<R: CommandRunner>(
@@ -437,6 +447,59 @@ mod tests {
             env::remove_var("Git_Smee_Hook_Arg_2");
             env::remove_var("GIT_SMEE_HOOK_ARGC");
         }
+    }
+
+    #[test]
+    fn given_user_prefixed_hook_arg_env_when_applying_then_unrelated_entries_are_preserved() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        // SAFETY: test serializes process environment mutation via ENV_MUTEX.
+        unsafe {
+            env::set_var("GIT_SMEE_HOOK_ARGS_FILE", "user-owned");
+            env::set_var("GIT_SMEE_HOOK_ARGUMENT_MODE", "strict");
+            env::set_var("GIT_SMEE_HOOK_ARG_2", "stale");
+        }
+
+        let mut command = Command::new("echo");
+        let hook_args = vec!["fresh".to_string()];
+        apply_hook_arg_env(&mut command, &hook_args);
+
+        let envs: Vec<(OsString, Option<OsString>)> = command
+            .get_envs()
+            .map(|(key, value)| (key.to_os_string(), value.map(OsString::from)))
+            .collect();
+
+        assert!(
+            !envs
+                .iter()
+                .any(|(key, value)| { key == "GIT_SMEE_HOOK_ARGS_FILE" && value.is_none() })
+        );
+        assert!(
+            !envs
+                .iter()
+                .any(|(key, value)| { key == "GIT_SMEE_HOOK_ARGUMENT_MODE" && value.is_none() })
+        );
+        assert!(
+            envs.iter()
+                .any(|(key, value)| { key == "GIT_SMEE_HOOK_ARG_2" && value.is_none() })
+        );
+
+        // SAFETY: test serializes process environment mutation via ENV_MUTEX.
+        unsafe {
+            env::remove_var("GIT_SMEE_HOOK_ARGS_FILE");
+            env::remove_var("GIT_SMEE_HOOK_ARGUMENT_MODE");
+            env::remove_var("GIT_SMEE_HOOK_ARG_2");
+        }
+    }
+
+    #[test]
+    fn given_hook_arg_contract_keys_when_matching_then_only_argc_and_numbered_args_match() {
+        assert!(is_hook_arg_env_key("GIT_SMEE_HOOK_ARGC"));
+        assert!(is_hook_arg_env_key("git_smee_hook_arg_12"));
+        assert!(!is_hook_arg_env_key("GIT_SMEE_HOOK_ARG"));
+        assert!(!is_hook_arg_env_key("GIT_SMEE_HOOK_ARG_"));
+        assert!(!is_hook_arg_env_key("GIT_SMEE_HOOK_ARG_0x1"));
+        assert!(!is_hook_arg_env_key("GIT_SMEE_HOOK_ARGS_FILE"));
+        assert!(!is_hook_arg_env_key("GIT_SMEE_HOOK_ARGUMENT_MODE"));
     }
 
     #[test]

--- a/crates/git-smee-core/src/installer.rs
+++ b/crates/git-smee-core/src/installer.rs
@@ -97,6 +97,8 @@ pub enum Error {
         #[source]
         source: std::io::Error,
     },
+    #[error("The specified configuration path exists but is not a regular file: {path}")]
+    ConfigPathNotAFile { path: String },
     #[error("Failed to resolve current executable path: {0}")]
     FailedToResolveCurrentExecutable(std::io::Error),
     #[error("Unsupported managed header prefix '{prefix}'. Expected '#' or 'REM'.")]
@@ -348,6 +350,12 @@ pub fn write_config_file(
 }
 
 fn ensure_can_write_config_file(config_file: &Path, force_overwrite: bool) -> Result<(), Error> {
+    if config_file.exists() && !config_file.is_file() {
+        return Err(Error::ConfigPathNotAFile {
+            path: config_file.to_string_lossy().to_string(),
+        });
+    }
+
     if !config_file.exists() || force_overwrite {
         return Ok(());
     }


### PR DESCRIPTION
Fixes #139
Fixes #132
Fixes #140

## Summary
- Narrow hook-argument environment cleanup to only the documented contract keys: `GIT_SMEE_HOOK_ARGC` and `GIT_SMEE_HOOK_ARG_<n>`.
- Preserve unrelated user-owned variables that merely share the `GIT_SMEE_HOOK_ARG...` prefix.
- Validate custom `init --config <path>` targets before managed-file checks or force-overwrite handling so directory targets get a user-facing not-a-file error in both normal and `--force` modes.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p git-smee-core hook_arg -- --nocapture`
- `cargo test -p git-smee-cli -F git2/vendored-openssl given_custom_config_directory_when_init -- --nocapture`
- `cargo test --workspace --all-features --locked -F git2/vendored-openssl -- --skip repository::tests::`
- `cargo clippy --workspace --all-targets --all-features --locked -F git2/vendored-openssl -- -D warnings`

## Notes
- Local CLI test builds require `git2/vendored-openssl` in this environment because `pkg-config`/OpenSSL development headers are not installed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved config path validation: commands now properly reject and report errors when `--config` points to a directory instead of a file.
  * Tightened hook argument environment variable validation to prevent similar-named variables from being incorrectly matched.

* **Tests**
  * Added CLI integration tests covering config path validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->