### PR TITLE
Preserve git hook path bytes and create missing hooks dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ cargo install --path crates/git-smee-cli
 
    By default, `install` only overwrites hook files previously managed by git-smee.
    Existing unmanaged hook files are preserved unless you pass `--force`.
+   If the repository uses `core.hooksPath` and that directory does not exist yet,
+   `install` creates the effective hooks directory before writing managed wrappers.
 
 That's it! Your hooks are now active. When Git triggers a hook, the installed wrapper runs the `git-smee` executable directly and executes the configured commands in order.
 

--- a/crates/git-smee-core/src/installer.rs
+++ b/crates/git-smee-core/src/installer.rs
@@ -54,6 +54,12 @@ pub enum Error {
     NotImplemented,
     #[error("Hooks directory not found: {0}")]
     HooksDirNotFound(String),
+    #[error("Failed to create hooks directory '{path}': {source}")]
+    FailedToCreateHooksDir {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
     #[error("No hooks present in the configuration to install")]
     NoHooksPresent,
     #[error("Failed to write hook '{path}': {source}")]
@@ -252,7 +258,13 @@ impl FileSystemHookInstaller {
                 })?;
         let hooks_path =
             crate::repository::resolve_git_path(&repository_root, Self::HOOKS_GIT_PATH_KEY)?;
-        if !hooks_path.exists() || !hooks_path.is_dir() {
+        if !hooks_path.exists() {
+            fs::create_dir_all(&hooks_path).map_err(|source| Error::FailedToCreateHooksDir {
+                path: hooks_path.to_string_lossy().to_string(),
+                source,
+            })?;
+        }
+        if !hooks_path.is_dir() {
             return Err(Error::HooksDirNotFound(
                 hooks_path.to_string_lossy().to_string(),
             ));

--- a/crates/git-smee-core/src/repository.rs
+++ b/crates/git-smee-core/src/repository.rs
@@ -283,7 +283,7 @@ pub fn resolve_git_path(repository_root: &Path, git_path: &str) -> Result<PathBu
         });
     }
 
-    let raw_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let raw_path = trim_git_output_path(&output.stdout);
     if raw_path.is_empty() {
         return Err(Error::EmptyGitPath {
             repository_root: repository_root.display().to_string(),
@@ -291,11 +291,31 @@ pub fn resolve_git_path(repository_root: &Path, git_path: &str) -> Result<PathBu
         });
     }
 
-    let path = PathBuf::from(raw_path);
+    let path = git_output_path_to_path_buf(raw_path, git_path)?;
     if path.is_absolute() {
         Ok(path)
     } else {
         Ok(repository_root.join(path))
+    }
+}
+
+#[cfg_attr(unix, allow(unused_variables))]
+fn git_output_path_to_path_buf(bytes: &[u8], flag: &str) -> Result<PathBuf, Error> {
+    #[cfg(unix)]
+    {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        Ok(PathBuf::from(OsString::from_vec(bytes.to_vec())))
+    }
+
+    #[cfg(not(unix))]
+    {
+        let value =
+            String::from_utf8(bytes.to_vec()).map_err(|_| Error::InvalidGitPathEncoding {
+                flag: flag.to_string(),
+            })?;
+        Ok(PathBuf::from(value))
     }
 }
 
@@ -665,6 +685,31 @@ mod tests {
     #[test]
     fn given_git_output_with_trailing_space_when_trimming_then_space_is_preserved() {
         assert_eq!(trim_git_output_path(b"/repo/path \n"), b"/repo/path ");
+    }
+
+    #[test]
+    fn given_git_path_output_with_trailing_space_when_resolving_then_space_is_preserved() {
+        let _guard = CWD_MUTEX.lock().unwrap();
+        let temp_dir = TempDir::new().unwrap();
+        git(temp_dir.path(), &["init"]);
+        git(temp_dir.path(), &["config", "core.hooksPath", ".githooks "]);
+
+        let resolved = resolve_git_path(temp_dir.path(), "hooks").unwrap();
+
+        assert_eq!(
+            normalize_path_for_compare(&resolved),
+            normalize_path_for_compare(&temp_dir.path().join(".githooks "))
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn given_non_utf8_git_path_output_when_decoding_then_bytes_are_preserved() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let path = git_output_path_to_path_buf(b".git/hooks-\xFF", "hooks").unwrap();
+
+        assert_eq!(path.as_os_str().as_bytes(), b".git/hooks-\xFF");
     }
 
     fn git(repo: &Path, args: &[&str]) {

--- a/crates/git-smee-core/tests/installer_integration.rs
+++ b/crates/git-smee-core/tests/installer_integration.rs
@@ -134,6 +134,7 @@ fn given_non_directory_custom_hooks_path_when_creating_installer_then_error_incl
     }
 }
 
+#[cfg(unix)]
 #[test]
 fn given_custom_hooks_path_with_trailing_space_when_installing_then_space_is_preserved() {
     let temp_dir = tempfile::tempdir().unwrap();

--- a/crates/git-smee-core/tests/installer_integration.rs
+++ b/crates/git-smee-core/tests/installer_integration.rs
@@ -96,11 +96,29 @@ fn given_worktree_when_installing_hooks_then_hooks_are_written_to_git_effective_
 }
 
 #[test]
-fn given_missing_custom_hooks_path_when_creating_installer_then_error_includes_resolved_path() {
+fn given_missing_custom_hooks_path_when_creating_installer_then_directory_is_created() {
     let temp_dir = tempfile::tempdir().unwrap();
     let repo = temp_dir.path().join("repo");
     init_repo(&repo);
     git(&repo, &["config", "core.hooksPath", ".missing-hooks"]);
+
+    let installer = FileSystemHookInstaller::from_path(repo.clone()).unwrap();
+
+    assert!(repo.join(".missing-hooks").is_dir());
+    assert_eq!(
+        normalize_path_for_compare(installer.effective_hooks_dir()),
+        normalize_path_for_compare(&repo.join(".missing-hooks"))
+    );
+}
+
+#[test]
+fn given_non_directory_custom_hooks_path_when_creating_installer_then_error_includes_resolved_path()
+{
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repo = temp_dir.path().join("repo");
+    init_repo(&repo);
+    git(&repo, &["config", "core.hooksPath", ".not-a-directory"]);
+    fs::write(repo.join(".not-a-directory"), "not a directory").unwrap();
 
     let result = FileSystemHookInstaller::from_path(repo.clone());
 
@@ -108,12 +126,33 @@ fn given_missing_custom_hooks_path_when_creating_installer_then_error_includes_r
         Err(Error::HooksDirNotFound(path)) => {
             assert_eq!(
                 normalize_path_for_compare(&PathBuf::from(path)),
-                normalize_path_for_compare(&repo.join(".missing-hooks"))
+                normalize_path_for_compare(&repo.join(".not-a-directory"))
             )
         }
         Ok(_) => panic!("expected hooks-dir-not-found error"),
         Err(error) => panic!("unexpected error: {error}"),
     }
+}
+
+#[test]
+fn given_custom_hooks_path_with_trailing_space_when_installing_then_space_is_preserved() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repo = temp_dir.path().join("repo");
+    init_repo(&repo);
+    write_config_fixture(&repo);
+    git(&repo, &["config", "core.hooksPath", ".githooks "]);
+    fs::create_dir(repo.join(".githooks ")).unwrap();
+
+    let config = read_config_from_repo(&repo);
+    let installer = FileSystemHookInstaller::from_path(repo.clone()).unwrap();
+
+    installer::install_hooks(&config, &installer).unwrap();
+
+    assert!(repo.join(".githooks ").join("pre-commit").exists());
+    assert_eq!(
+        normalize_path_for_compare(installer.effective_hooks_dir()),
+        normalize_path_for_compare(&repo.join(".githooks "))
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #76
Fixes #128
Fixes #135

## Summary
- preserve raw Git path output bytes on Unix and trim only CR/LF when resolving `git rev-parse --git-path` values
- preserve significant leading/trailing spaces in `core.hooksPath` and add regressions for hook paths with trailing spaces
- create missing effective hooks directories during install while still rejecting existing non-directory paths
- document custom `core.hooksPath` auto-creation behavior

## Validation
- `cargo test -p git-smee-core`
- `cargo fmt --all -- --check`
- `cargo clippy -p git-smee-core --all-targets --all-features --locked -- -D warnings`

## Validation note
- Full workspace/CLI validation was attempted, but this runner lacks `pkg-config`/OpenSSL discovery for `openssl-sys`, so `cargo test -p git-smee-cli -- --skip repository::tests::` failed before compiling project code. The core crate owns the touched behavior and passed tests/clippy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hooks directory is now automatically created when using `git smee install` with `core.hooksPath` set to a missing directory.

* **Bug Fixes**
  * Improved handling of paths containing trailing spaces and non-UTF-8 byte sequences.

* **Documentation**
  * Updated README to clarify hooks directory creation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->