### PR TITLE
Harden stdin replay follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,12 @@ On all platforms, git-smee also exports forwarded hook args as environment varia
 When `git smee run` receives stdin, it buffers that payload once and replays identical bytes to
 each configured command for the hook. This keeps stdin-driven hooks such as `pre-push`,
 `pre-receive`, and `post-receive` deterministic even when multiple commands are configured for
-the same phase.
+the same phase. The default buffered-stdin limit is 10 MiB; set
+`GIT_SMEE_HOOK_STDIN_LIMIT_BYTES=<bytes>` to raise or lower it for unusually large hooks.
+
+`proc-receive` is an interactive pkt-line protocol, so git-smee does not pre-buffer stdin for
+that phase. The configured `proc-receive` command inherits stdin directly to avoid blocking the
+protocol handshake before the command starts.
 
 ## CLI Commands
 

--- a/crates/git-smee-cli/src/main.rs
+++ b/crates/git-smee-cli/src/main.rs
@@ -7,12 +7,16 @@ use std::{
 
 use clap::Parser;
 use git_smee_core::{
-    DEFAULT_CONFIG_FILE_NAME, SmeeConfig, config, executor,
+    DEFAULT_CONFIG_FILE_NAME, SmeeConfig,
+    config::{self, LifeCyclePhase},
+    executor,
     installer::{self, HookInstaller, HookScriptOptions},
     repository,
 };
 
-const MAX_HOOK_STDIN_BYTES: u64 = 10 * 1024 * 1024;
+const DEFAULT_MAX_HOOK_STDIN_BYTES: u64 = 10 * 1024 * 1024;
+const HOOK_STDIN_LIMIT_ENV: &str = "GIT_SMEE_HOOK_STDIN_LIMIT_BYTES";
+const DEFAULT_HOOK_STDIN_LIMIT_DISPLAY: &str = "10 MiB";
 
 #[derive(clap::Parser)]
 #[command(name = "git-smee")]
@@ -79,9 +83,9 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         }
         Command::Run { hook, hook_args } => {
             repository::ensure_in_repo_root()?;
-            let stdin_payload = read_hook_stdin()?;
+            let phase = LifeCyclePhase::from_str(&hook)?;
+            let stdin_payload = read_hook_stdin_for_phase(phase)?;
             let config = read_config_file(&config_path)?;
-            let phase = config::LifeCyclePhase::from_str(&hook)?;
             executor::execute_hook_with_args_and_stdin(
                 &config,
                 phase,
@@ -131,24 +135,59 @@ fn normalize_user_config_path(path: PathBuf, invocation_dir: &Path) -> PathBuf {
     }
 }
 
+fn read_hook_stdin_for_phase(phase: LifeCyclePhase) -> io::Result<Option<Vec<u8>>> {
+    // proc-receive is an interactive pkt-line protocol: Git waits for the hook to
+    // answer before closing stdin, so buffering until EOF would deadlock before
+    // the configured command is spawned. Let the command inherit stdin instead.
+    if phase == LifeCyclePhase::ProcReceive {
+        return Ok(None);
+    }
+    read_hook_stdin()
+}
+
 fn read_hook_stdin() -> io::Result<Option<Vec<u8>>> {
     let stdin = io::stdin();
     if stdin.is_terminal() {
         return Ok(None);
     }
 
-    let mut payload = Vec::with_capacity(MAX_HOOK_STDIN_BYTES as usize);
+    let max_hook_stdin_bytes = max_hook_stdin_bytes()?;
+    let mut payload = Vec::new();
     stdin
         .lock()
-        .take(MAX_HOOK_STDIN_BYTES + 1)
+        .take(max_hook_stdin_bytes + 1)
         .read_to_end(&mut payload)?;
-    if payload.len() as u64 > MAX_HOOK_STDIN_BYTES {
+    if payload.len() as u64 > max_hook_stdin_bytes {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
-            format!("hook stdin exceeds the {MAX_HOOK_STDIN_BYTES} byte limit"),
+            format!(
+                "hook stdin exceeds the {} limit",
+                hook_stdin_limit_display(max_hook_stdin_bytes)
+            ),
         ));
     }
     Ok(Some(payload))
+}
+
+fn max_hook_stdin_bytes() -> io::Result<u64> {
+    let Some(value) = env::var_os(HOOK_STDIN_LIMIT_ENV) else {
+        return Ok(DEFAULT_MAX_HOOK_STDIN_BYTES);
+    };
+    let value = value.to_string_lossy();
+    value.parse::<u64>().map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("{HOOK_STDIN_LIMIT_ENV} must be an unsigned byte count: {error}"),
+        )
+    })
+}
+
+fn hook_stdin_limit_display(limit: u64) -> String {
+    if limit == DEFAULT_MAX_HOOK_STDIN_BYTES {
+        DEFAULT_HOOK_STDIN_LIMIT_DISPLAY.to_string()
+    } else {
+        format!("{limit} bytes")
+    }
 }
 
 #[cfg(unix)]

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -853,7 +853,7 @@ fn given_proc_receive_hook_when_running_then_stdin_is_inherited_by_command() {
     let output = test_repo.path.join("proc-receive-stdin.txt");
     let command = stdin_capture_command(&output);
     test_repo.write_config(&format!("[[proc-receive]]\ncommand = {command:?}\n"));
-    let stdin_payload = "version=1\0push-options\n0000";
+    let stdin_payload = "version=1\0push-options\n0000\n";
 
     let mut cmd = Command::new(cargo::cargo_bin!("git-smee"));
     cmd.current_dir(&test_repo.path)

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -816,6 +816,58 @@ fn given_stdin_driven_hook_with_multiple_commands_when_running_then_each_command
     );
 }
 
+#[test]
+fn given_oversized_hook_stdin_when_running_then_cli_rejects_with_clear_error() {
+    let test_repo = common::TestRepo::default();
+    test_repo.write_config("[[pre-push]]\ncommand = \"true\"\n");
+
+    let mut cmd = Command::new(cargo::cargo_bin!("git-smee"));
+    cmd.current_dir(&test_repo.path)
+        .env("GIT_SMEE_HOOK_STDIN_LIMIT_BYTES", "4")
+        .args(["run", "pre-push"])
+        .write_stdin("abcde")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "hook stdin exceeds the 4 bytes limit",
+        ));
+}
+
+#[test]
+fn given_hook_command_ignores_large_stdin_when_running_then_hook_succeeds() {
+    let test_repo = common::TestRepo::default();
+    let command = if cfg!(windows) { "exit /b 0" } else { "true" };
+    test_repo.write_config(&format!("[[pre-push]]\ncommand = {command:?}\n"));
+
+    let mut cmd = Command::new(cargo::cargo_bin!("git-smee"));
+    cmd.current_dir(&test_repo.path)
+        .args(["run", "pre-push"])
+        .write_stdin(vec![b'x'; 128 * 1024])
+        .assert()
+        .success();
+}
+
+#[test]
+fn given_proc_receive_hook_when_running_then_stdin_is_inherited_by_command() {
+    let test_repo = common::TestRepo::default();
+    let output = test_repo.path.join("proc-receive-stdin.txt");
+    let command = stdin_capture_command(&output);
+    test_repo.write_config(&format!("[[proc-receive]]\ncommand = {command:?}\n"));
+    let stdin_payload = "version=1\0push-options\n0000";
+
+    let mut cmd = Command::new(cargo::cargo_bin!("git-smee"));
+    cmd.current_dir(&test_repo.path)
+        .args(["run", "proc-receive"])
+        .write_stdin(stdin_payload)
+        .assert()
+        .success();
+
+    assert_eq!(
+        normalize_test_newlines(&fs::read_to_string(output).unwrap()),
+        stdin_payload
+    );
+}
+
 #[cfg(windows)]
 fn normalize_test_newlines(value: &str) -> String {
     value.replace("\r\n", "\n")

--- a/crates/git-smee-core/src/executor.rs
+++ b/crates/git-smee-core/src/executor.rs
@@ -1,4 +1,9 @@
-use std::{env, io::Write, process::Stdio};
+use std::{
+    env,
+    io::{self, ErrorKind, Write},
+    process::Stdio,
+    thread,
+};
 
 #[cfg(windows)]
 use std::path::PathBuf;
@@ -142,18 +147,29 @@ impl CommandRunner for PlatformCommandRunner<'_> {
         }
 
         let mut child = shell_command.spawn()?;
-        let stdin_result = if let Some(stdin_payload) = stdin_payload {
-            if let Some(mut stdin) = child.stdin.take() {
-                stdin.write_all(stdin_payload)
-            } else {
-                Ok(())
-            }
+        if let Some(stdin_payload) = stdin_payload {
+            let Some(mut stdin) = child.stdin.take() else {
+                return child.wait().map(|status| status.code());
+            };
+            let stdin_payload = stdin_payload.to_vec();
+            let stdin_writer = thread::spawn(move || {
+                match stdin.write_all(&stdin_payload) {
+                    // Hook commands are allowed to ignore or close stdin early. If the
+                    // command exits successfully, a broken pipe while replaying the
+                    // buffered hook payload should not fail the hook run.
+                    Err(error) if error.kind() == ErrorKind::BrokenPipe => Ok(()),
+                    result => result,
+                }
+            });
+            let wait_result = child.wait().map(|status| status.code());
+            let stdin_result = stdin_writer
+                .join()
+                .unwrap_or_else(|_| Err(io::Error::other("stdin writer thread panicked")));
+            stdin_result?;
+            wait_result
         } else {
-            Ok(())
-        };
-        let wait_result = child.wait().map(|status| status.code());
-        stdin_result?;
-        wait_result
+            child.wait().map(|status| status.code())
+        }
     }
 
     fn shell_display(&self) -> &'static str {


### PR DESCRIPTION
Follow-up to #123 addressing bot review feedback after the original PR merged.\n\nChanges:\n- Avoid blocking hook execution when a configured command ignores stdin by writing replayed stdin on a helper thread and treating BrokenPipe as non-fatal.\n- Make the stdin cap configurable via GIT_SMEE_HOOK_STDIN_LIMIT_BYTES and document the 10 MiB default.\n- Skip pre-buffering for proc-receive so the interactive pkt-line protocol can be handled by the configured command.\n- Add CLI regression coverage for oversized stdin rejection, commands that ignore stdin, and proc-receive stdin inheritance.\n\nLocal validation:\n- cargo fmt --all -- --check\n- cargo test --workspace --all-features --locked -F git2/vendored-openssl -- --skip repository::tests::\n- cargo clippy --workspace --all-targets --all-features --locked -F git2/vendored-openssl -- -D warnings