### PR TITLE
test(core): share process-state test lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ cargo audit
 
 GitHub Actions CI validates Linux (stable/beta/nightly), macOS (stable), Windows (stable), and MSRV (`1.88.0`) build/test compatibility.
 
+Tests that mutate process-global state (environment variables or the current working directory) must hold the shared `process_state_lock` test helper for the entire setup/exercise/restore window. Do not add module-local env/cwd mutexes: Rust 2024 treats environment mutation as unsafe unless all process-wide access is externally synchronized.
+
 Release archives publish adjacent `.sha256` files. Verify downloads with:
 
 ```bash

--- a/crates/git-smee-core/src/executor.rs
+++ b/crates/git-smee-core/src/executor.rs
@@ -356,11 +356,9 @@ mod tests {
     use assert2::assert;
     use proptest::prelude::*;
 
-    use crate::config::HookDefinition;
+    use crate::{config::HookDefinition, test_support::process_state_lock};
 
     use super::*;
-
-    static ENV_MUTEX: Mutex<()> = Mutex::new(());
 
     enum PlannedResult {
         Exit(Option<i32>),
@@ -541,8 +539,8 @@ mod tests {
 
     #[test]
     fn given_mixed_case_hook_arg_env_when_applying_then_existing_entries_are_removed() {
-        let _guard = ENV_MUTEX.lock().unwrap();
-        // SAFETY: test serializes process environment mutation via ENV_MUTEX.
+        let _guard = process_state_lock();
+        // SAFETY: test serializes process environment mutation via process_state_lock.
         unsafe {
             env::set_var("Git_Smee_Hook_Arg_2", "stale");
             env::set_var("GIT_SMEE_HOOK_ARGC", "7");
@@ -571,7 +569,7 @@ mod tests {
             key == "GIT_SMEE_HOOK_ARG_2" && value.as_ref() == Some(&OsString::from("beta"))
         }));
 
-        // SAFETY: test serializes process environment mutation via ENV_MUTEX.
+        // SAFETY: test serializes process environment mutation via process_state_lock.
         unsafe {
             env::remove_var("Git_Smee_Hook_Arg_2");
             env::remove_var("GIT_SMEE_HOOK_ARGC");
@@ -580,8 +578,8 @@ mod tests {
 
     #[test]
     fn given_user_prefixed_hook_arg_env_when_applying_then_unrelated_entries_are_preserved() {
-        let _guard = ENV_MUTEX.lock().unwrap();
-        // SAFETY: test serializes process environment mutation via ENV_MUTEX.
+        let _guard = process_state_lock();
+        // SAFETY: test serializes process environment mutation via process_state_lock.
         unsafe {
             env::set_var("GIT_SMEE_HOOK_ARGS_FILE", "user-owned");
             env::set_var("GIT_SMEE_HOOK_ARGUMENT_MODE", "strict");
@@ -612,7 +610,7 @@ mod tests {
                 .any(|(key, value)| { key == "GIT_SMEE_HOOK_ARG_2" && value.is_none() })
         );
 
-        // SAFETY: test serializes process environment mutation via ENV_MUTEX.
+        // SAFETY: test serializes process environment mutation via process_state_lock.
         unsafe {
             env::remove_var("GIT_SMEE_HOOK_ARGS_FILE");
             env::remove_var("GIT_SMEE_HOOK_ARGUMENT_MODE");
@@ -635,7 +633,7 @@ mod tests {
 
     #[test]
     fn given_empty_hook_args_when_applying_then_argc_is_zero_and_no_indexed_args_are_added() {
-        let _guard = ENV_MUTEX.lock().unwrap();
+        let _guard = process_state_lock();
         let mut command = Command::new("echo");
 
         apply_hook_arg_env(&mut command, &[]);

--- a/crates/git-smee-core/src/lib.rs
+++ b/crates/git-smee-core/src/lib.rs
@@ -10,4 +10,6 @@ pub use crate::repository::{ensure_in_repo_root, find_git_root};
 
 pub const DEFAULT_CONFIG_FILE_NAME: &str = ".git-smee.toml";
 #[cfg(test)]
+mod test_support;
+#[cfg(test)]
 mod tests {}

--- a/crates/git-smee-core/src/repository.rs
+++ b/crates/git-smee-core/src/repository.rs
@@ -688,7 +688,6 @@ mod tests {
 
     #[test]
     fn given_git_path_output_with_trailing_space_when_resolving_then_space_is_preserved() {
-        let _guard = process_state_lock();
         let temp_dir = TempDir::new().unwrap();
         git(temp_dir.path(), &["init"]);
         git(temp_dir.path(), &["config", "core.hooksPath", ".githooks "]);

--- a/crates/git-smee-core/src/repository.rs
+++ b/crates/git-smee-core/src/repository.rs
@@ -342,14 +342,13 @@ pub fn resolve_hooks_path(repository_root: &Path) -> Result<PathBuf, Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{fs, sync::Mutex};
+    use crate::test_support::process_state_lock;
+    use std::fs;
     use tempfile::TempDir;
-
-    static CWD_MUTEX: Mutex<()> = Mutex::new(());
 
     #[test]
     fn given_current_dir_is_git_root_when_finding_root_then_returns_current_dir() {
-        let _guard = CWD_MUTEX.lock().unwrap();
+        let _guard = process_state_lock();
         let temp_dir = TempDir::new().unwrap();
         git(temp_dir.path(), &["init"]);
 
@@ -370,7 +369,7 @@ mod tests {
 
     #[test]
     fn given_current_dir_is_subdirectory_of_repo_when_finding_root_then_returns_repo_root() {
-        let _guard = CWD_MUTEX.lock().unwrap();
+        let _guard = process_state_lock();
         let temp_dir = TempDir::new().unwrap();
         git(temp_dir.path(), &["init"]);
         let sub_dir = temp_dir.path().join("subdir");
@@ -393,7 +392,7 @@ mod tests {
 
     #[test]
     fn given_current_dir_is_deeply_nested_subdirectory_when_finding_root_then_returns_repo_root() {
-        let _guard = CWD_MUTEX.lock().unwrap();
+        let _guard = process_state_lock();
         let temp_dir = TempDir::new().unwrap();
         git(temp_dir.path(), &["init"]);
 
@@ -429,7 +428,7 @@ mod tests {
 
     #[test]
     fn given_bare_repo_when_finding_root_then_returns_current_dir() {
-        let _guard = CWD_MUTEX.lock().unwrap();
+        let _guard = process_state_lock();
         let temp_dir = TempDir::new().unwrap();
         git(temp_dir.path(), &["init", "--bare"]);
 
@@ -449,7 +448,7 @@ mod tests {
 
     #[test]
     fn given_in_git_repo_when_ensuring_in_repo_root_then_succeeds() {
-        let _guard = CWD_MUTEX.lock().unwrap();
+        let _guard = process_state_lock();
         let temp_dir = TempDir::new().unwrap();
         git(temp_dir.path(), &["init"]);
         let sub_dir = temp_dir.path().join("subdir");
@@ -475,7 +474,7 @@ mod tests {
 
     #[test]
     fn given_not_in_git_repo_when_ensuring_in_repo_root_then_returns_error() {
-        let _guard = CWD_MUTEX.lock().unwrap();
+        let _guard = process_state_lock();
         let temp_dir = TempDir::new().unwrap();
         // Deliberately don't create .git directory
 
@@ -492,7 +491,7 @@ mod tests {
 
     #[test]
     fn given_bare_repo_when_ensuring_in_repo_root_then_succeeds() {
-        let _guard = CWD_MUTEX.lock().unwrap();
+        let _guard = process_state_lock();
         let temp_dir = TempDir::new().unwrap();
         git(temp_dir.path(), &["init", "--bare"]);
         let original_dir = env::current_dir().unwrap();
@@ -573,7 +572,7 @@ mod tests {
 
     #[test]
     fn given_current_dir_is_git_directory_when_finding_root_then_returns_worktree_root() {
-        let _guard = CWD_MUTEX.lock().unwrap();
+        let _guard = process_state_lock();
         let temp_dir = TempDir::new().unwrap();
         git(temp_dir.path(), &["init"]);
         let git_dir = temp_dir.path().join(".git");
@@ -594,7 +593,7 @@ mod tests {
     #[test]
     fn given_current_dir_is_git_directory_when_ensuring_in_repo_root_then_changes_to_worktree_root()
     {
-        let _guard = CWD_MUTEX.lock().unwrap();
+        let _guard = process_state_lock();
         let temp_dir = TempDir::new().unwrap();
         git(temp_dir.path(), &["init"]);
         let git_dir = temp_dir.path().join(".git");
@@ -615,7 +614,7 @@ mod tests {
 
     #[test]
     fn given_git_dir_env_in_hook_context_when_finding_root_then_returns_worktree_root() {
-        let _guard = CWD_MUTEX.lock().unwrap();
+        let _guard = process_state_lock();
         let temp_dir = TempDir::new().unwrap();
         git(temp_dir.path(), &["init"]);
         let git_dir = temp_dir.path().join(".git");
@@ -643,7 +642,7 @@ mod tests {
 
     #[test]
     fn given_bare_git_dir_env_outside_repo_when_finding_root_then_returns_bare_repo_path() {
-        let _guard = CWD_MUTEX.lock().unwrap();
+        let _guard = process_state_lock();
         let temp_dir = TempDir::new().unwrap();
         let bare_repo = temp_dir.path().join("remote.git");
         fs::create_dir(&bare_repo).unwrap();
@@ -689,7 +688,7 @@ mod tests {
 
     #[test]
     fn given_git_path_output_with_trailing_space_when_resolving_then_space_is_preserved() {
-        let _guard = CWD_MUTEX.lock().unwrap();
+        let _guard = process_state_lock();
         let temp_dir = TempDir::new().unwrap();
         git(temp_dir.path(), &["init"]);
         git(temp_dir.path(), &["config", "core.hooksPath", ".githooks "]);
@@ -749,7 +748,7 @@ mod tests {
 
     #[test]
     fn given_explicit_repo_git_helper_when_git_dir_env_is_contaminated_then_it_ignores_it() {
-        let _guard = CWD_MUTEX.lock().unwrap();
+        let _guard = process_state_lock();
         let temp_dir = TempDir::new().unwrap();
         let bare_repo = temp_dir.path().join("remote.git");
         fs::create_dir(&bare_repo).unwrap();

--- a/crates/git-smee-core/src/test_support.rs
+++ b/crates/git-smee-core/src/test_support.rs
@@ -1,0 +1,13 @@
+use std::sync::{Mutex, MutexGuard};
+
+static PROCESS_STATE_MUTEX: Mutex<()> = Mutex::new(());
+
+/// Serializes tests that mutate process-global state such as environment
+/// variables or the current working directory.
+///
+/// Rust 2024 makes environment mutation unsafe because other threads can read or
+/// mutate the same process state concurrently. Hold this guard for the full
+/// setup/exercise/restore window whenever a test changes env vars or cwd.
+pub(crate) fn process_state_lock() -> MutexGuard<'static, ()> {
+    PROCESS_STATE_MUTEX.lock().unwrap()
+}


### PR DESCRIPTION
## Summary
- add a shared test-only process-state mutex for environment/current-directory mutations
- route executor and repository tests through the shared lock instead of module-local mutexes
- document the testing rule for future contributors

Fixes #129

## Validation
- cargo fmt --all -- --check
- cargo test --workspace --all-targets --all-features
- CARGO_TARGET_DIR=/home/er/projects/git-smee/target cargo clippy --workspace --all-targets --all-features -- -D warnings

Note: an initial clippy attempt without shared target failed because the cron VM ran out of disk while vendored OpenSSL was rebuilding; rerun with the existing shared target passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by implementing centralized synchronization for tests that modify process-global state (environment variables and working directory).

* **Documentation**
  * Added guidance on proper test synchronization requirements for tests that mutate process-level state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->