### PR TITLE
Add git smee doctor diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,6 +350,8 @@ dependencies = [
  "git-smee-core",
  "git2",
  "predicates",
+ "serde",
+ "serde_json",
  "tempfile",
 ]
 
@@ -550,6 +552,12 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -959,6 +967,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1392,3 +1413,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/README.md
+++ b/README.md
@@ -232,7 +232,13 @@ protocol handshake before the command starts.
 git smee init [--force] [--config <path>]       # Initialize a config file
 git smee install [--force] [--config <path>]    # Install hooks from the selected config
 git smee [--config <path>] run <hook> [hook-args...]           # Run a specific git hook
+git smee [--config <path>] doctor [--json]      # Diagnose repository setup and hook drift
 ```
+
+Run `git smee doctor` when onboarding a repository, after changing `core.hooksPath`, or when a
+hook does not fire as expected. The human-readable report groups `ok`, `warnings`, and `errors`
+with remediation commands; `--json` emits the same stable fields for automation. Doctor exits
+successfully when no errors are present and exits non-zero when setup errors need action.
 
 ## How it works (high level)
 

--- a/crates/git-smee-cli/Cargo.toml
+++ b/crates/git-smee-cli/Cargo.toml
@@ -11,6 +11,8 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 git-smee-core = { path = "../git-smee-core" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [dev-dependencies]
 assert_cmd = "2.1"

--- a/crates/git-smee-cli/src/main.rs
+++ b/crates/git-smee-cli/src/main.rs
@@ -1,6 +1,7 @@
 use std::{
     env,
     ffi::OsStr,
+    fs,
     io::{self, IsTerminal, Read},
     path::{Component, Path, PathBuf},
     str::FromStr,
@@ -11,9 +12,10 @@ use git_smee_core::{
     DEFAULT_CONFIG_FILE_NAME, SmeeConfig,
     config::{self, LifeCyclePhase},
     executor,
-    installer::{self, HookInstaller, HookScriptOptions},
+    installer::{self, HookInstaller, HookScriptOptions, MANAGED_FILE_MARKER},
     repository,
 };
+use serde::Serialize;
 
 const DEFAULT_MAX_HOOK_STDIN_BYTES: u64 = 10 * 1024 * 1024;
 const HOOK_STDIN_LIMIT_ENV: &str = "GIT_SMEE_HOOK_STDIN_LIMIT_BYTES";
@@ -53,6 +55,11 @@ enum Command {
     Initialize {
         #[arg(long, help = "Overwrite an existing .git-smee.toml file")]
         force: bool,
+    },
+    #[command(name = "doctor", about = "Diagnose git-smee repository setup")]
+    Doctor {
+        #[arg(long, help = "Emit a stable JSON diagnostics report")]
+        json: bool,
     },
 }
 
@@ -117,6 +124,221 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 installer::write_config_file(&config_path, &default_config, force)?;
             }
             Ok(())
+        }
+        Command::Doctor { json } => run_doctor(&config_path, json),
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct DoctorReport {
+    status: DoctorStatus,
+    repository_root: Option<String>,
+    hooks_dir: Option<String>,
+    config_path: String,
+    ok: Vec<String>,
+    warnings: Vec<String>,
+    errors: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum DoctorStatus {
+    Ok,
+    Warning,
+    Error,
+}
+
+fn run_doctor(config_path: &Path, json: bool) -> Result<(), Box<dyn std::error::Error>> {
+    let report = build_doctor_report(config_path);
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print_doctor_report(&report);
+    }
+    if report.errors.is_empty() {
+        Ok(())
+    } else {
+        Err("doctor found repository setup errors".into())
+    }
+}
+
+fn build_doctor_report(config_path: &Path) -> DoctorReport {
+    let mut report = DoctorReport {
+        status: DoctorStatus::Ok,
+        repository_root: None,
+        hooks_dir: None,
+        config_path: config_path.display().to_string(),
+        ok: Vec::new(),
+        warnings: Vec::new(),
+        errors: Vec::new(),
+    };
+
+    let repository_root = match repository::find_git_root() {
+        Ok(root) => {
+            report.ok.push("inside a Git repository".to_string());
+            report.repository_root = Some(root.display().to_string());
+            root
+        }
+        Err(error) => {
+            report.errors.push(format!(
+                "not inside a Git repository; run git smee doctor from a repository ({error})"
+            ));
+            return finish_doctor_report(report);
+        }
+    };
+
+    let hooks_dir = match repository::resolve_git_path(
+        &repository_root,
+        installer::FileSystemHookInstaller::HOOKS_GIT_PATH_KEY,
+    ) {
+        Ok(path) => {
+            report.hooks_dir = Some(path.display().to_string());
+            if path.exists() && path.is_dir() {
+                report
+                    .ok
+                    .push(format!("hooks directory exists at {}", path.display()));
+            } else if path.exists() {
+                report.errors.push(format!(
+                    "effective hooks path is not a directory: {}; fix core.hooksPath or remove the file",
+                    path.display()
+                ));
+            } else {
+                report.warnings.push(format!(
+                    "hooks directory does not exist yet at {}; run git smee install to create it",
+                    path.display()
+                ));
+            }
+            path
+        }
+        Err(error) => {
+            report.errors.push(format!(
+                "could not resolve effective hooks directory; check git core.hooksPath ({error})"
+            ));
+            return finish_doctor_report(report);
+        }
+    };
+
+    let config = match read_config_file(config_path) {
+        Ok(config) => {
+            report
+                .ok
+                .push(format!("config parses from {}", config_path.display()));
+            if config.hooks.is_empty() {
+                report.errors.push(
+                    "configuration contains no hooks; add at least one [[hook-name]] entry"
+                        .to_string(),
+                );
+            } else {
+                report.ok.push(format!(
+                    "{} configured hook phase(s) are valid",
+                    config.hooks.len()
+                ));
+            }
+            config
+        }
+        Err(error) => {
+            report.errors.push(format!(
+                "config problem at {}: {error}; run git smee init or fix the TOML file",
+                config_path.display()
+            ));
+            return finish_doctor_report(report);
+        }
+    };
+
+    let expected_config_path = normalize_config_path_for_hook_script(config_path, &repository_root)
+        .unwrap_or_else(|_| config_path.to_path_buf());
+    let expected_exe = env::current_exe().ok();
+    let expected_config = expected_config_path.to_string_lossy().to_string();
+
+    let mut phases: Vec<_> = config.hooks.keys().copied().collect();
+    phases.sort_by_key(|phase| phase.as_str());
+    for phase in phases {
+        let hook_path = hooks_dir.join(phase.as_str());
+        if !hook_path.exists() {
+            report.errors.push(format!(
+                "missing managed wrapper for {phase} at {}; run git smee install",
+                hook_path.display()
+            ));
+            continue;
+        }
+        if !hook_path.is_file() {
+            report.errors.push(format!(
+                "hook path for {phase} is not a regular file: {}; remove it or fix core.hooksPath",
+                hook_path.display()
+            ));
+            continue;
+        }
+        let content = match fs::read_to_string(&hook_path) {
+            Ok(content) => content,
+            Err(error) => {
+                report.errors.push(format!(
+                    "cannot read hook wrapper for {phase} at {}: {error}",
+                    hook_path.display()
+                ));
+                continue;
+            }
+        };
+        if !content.contains(MANAGED_FILE_MARKER) {
+            report.errors.push(format!(
+                "unmanaged hook file blocks install for {phase} at {}; move it aside or run git smee install --force",
+                hook_path.display()
+            ));
+            continue;
+        }
+        report
+            .ok
+            .push(format!("managed wrapper is installed for {phase}"));
+        if !content.contains(&expected_config) {
+            report.warnings.push(format!(
+                "stale managed wrapper for {phase}: expected config path {}; run git smee install",
+                expected_config
+            ));
+        }
+        if let Some(expected_exe) = &expected_exe
+            && !content.contains(&expected_exe.to_string_lossy().to_string())
+        {
+            report.warnings.push(format!(
+                "stale managed wrapper for {phase}: expected executable {}; run git smee install",
+                expected_exe.display()
+            ));
+        }
+    }
+
+    finish_doctor_report(report)
+}
+
+fn finish_doctor_report(mut report: DoctorReport) -> DoctorReport {
+    report.status = if !report.errors.is_empty() {
+        DoctorStatus::Error
+    } else if !report.warnings.is_empty() {
+        DoctorStatus::Warning
+    } else {
+        DoctorStatus::Ok
+    };
+    report
+}
+
+fn print_doctor_report(report: &DoctorReport) {
+    println!("git-smee doctor: {:?}", report.status);
+    if let Some(root) = &report.repository_root {
+        println!("repository root: {root}");
+    }
+    if let Some(hooks_dir) = &report.hooks_dir {
+        println!("hooks directory: {hooks_dir}");
+    }
+    println!("config path: {}", report.config_path);
+    print_doctor_section("ok", &report.ok);
+    print_doctor_section("warnings", &report.warnings);
+    print_doctor_section("errors", &report.errors);
+}
+
+fn print_doctor_section(name: &str, items: &[String]) {
+    println!("{name}:");
+    if items.is_empty() {
+        println!("  - none");
+    } else {
+        for item in items {
+            println!("  - {item}");
         }
     }
 }

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -88,6 +88,158 @@ fn given_git_smee_when_install_then_hooks_are_present() {
 }
 
 #[test]
+fn given_healthy_repo_when_doctor_then_successful_sections_are_reported() {
+    let test_repo = common::TestRepo::default();
+    Command::new(cargo::cargo_bin!("git-smee"))
+        .current_dir(&test_repo.path)
+        .arg("install")
+        .assert()
+        .success();
+
+    Command::new(cargo::cargo_bin!("git-smee"))
+        .current_dir(&test_repo.path)
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("git-smee doctor: Ok")
+                .and(predicate::str::contains("ok:"))
+                .and(predicate::str::contains("warnings:\n  - none"))
+                .and(predicate::str::contains("errors:\n  - none"))
+                .and(predicate::str::contains(
+                    "managed wrapper is installed for pre-commit",
+                )),
+        );
+}
+
+#[test]
+fn given_healthy_repo_when_doctor_json_then_stable_json_is_reported() {
+    let test_repo = common::TestRepo::default();
+    Command::new(cargo::cargo_bin!("git-smee"))
+        .current_dir(&test_repo.path)
+        .arg("install")
+        .assert()
+        .success();
+
+    Command::new(cargo::cargo_bin!("git-smee"))
+        .current_dir(&test_repo.path)
+        .args(["doctor", "--json"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains(r#""status": "ok""#)
+                .and(predicate::str::contains(r#""repository_root""#))
+                .and(predicate::str::contains(r#""hooks_dir""#))
+                .and(predicate::str::contains(r#""errors": []"#)),
+        );
+}
+
+#[test]
+fn given_missing_config_when_doctor_then_actionable_error_is_reported() {
+    let test_repo = common::TestRepo::default();
+    fs::remove_file(test_repo.config_path()).expect("failed to remove config");
+
+    Command::new(cargo::cargo_bin!("git-smee"))
+        .current_dir(&test_repo.path)
+        .arg("doctor")
+        .assert()
+        .failure()
+        .stdout(
+            predicate::str::contains("errors:")
+                .and(predicate::str::contains("config problem"))
+                .and(predicate::str::contains("run git smee init")),
+        )
+        .stderr(predicate::str::contains(
+            "doctor found repository setup errors",
+        ));
+}
+
+#[test]
+fn given_malformed_config_when_doctor_then_parse_error_is_reported() {
+    let test_repo = common::TestRepo::default();
+    test_repo.write_config("[[pre-commit]]\ncommand = ");
+
+    Command::new(cargo::cargo_bin!("git-smee"))
+        .current_dir(&test_repo.path)
+        .arg("doctor")
+        .assert()
+        .failure()
+        .stdout(
+            predicate::str::contains("config problem")
+                .and(predicate::str::contains("fix the TOML file")),
+        );
+}
+
+#[test]
+fn given_unmanaged_hook_when_doctor_then_collision_is_reported() {
+    let test_repo = common::TestRepo::default();
+    let pre_commit = test_repo.path.join(".git/hooks/pre-commit");
+    fs::write(&pre_commit, "#!/usr/bin/env sh\necho unmanaged\n").unwrap();
+
+    Command::new(cargo::cargo_bin!("git-smee"))
+        .current_dir(&test_repo.path)
+        .arg("doctor")
+        .assert()
+        .failure()
+        .stdout(
+            predicate::str::contains("unmanaged hook file blocks install for pre-commit")
+                .and(predicate::str::contains("git smee install --force")),
+        );
+}
+
+#[test]
+fn given_custom_hooks_path_when_doctor_then_effective_path_is_reported() {
+    let test_repo = common::TestRepo::default();
+    std::process::Command::new("git")
+        .current_dir(&test_repo.path)
+        .args(["config", "core.hooksPath", ".githooks"])
+        .status()
+        .expect("failed to configure hooksPath");
+
+    Command::new(cargo::cargo_bin!("git-smee"))
+        .current_dir(&test_repo.path)
+        .arg("doctor")
+        .assert()
+        .failure()
+        .stdout(
+            predicate::str::contains("hooks directory:")
+                .and(predicate::str::contains(".githooks"))
+                .and(predicate::str::contains("run git smee install")),
+        );
+}
+
+#[test]
+fn given_stale_managed_hook_when_doctor_then_reinstall_warning_is_reported() {
+    let test_repo = common::TestRepo::default();
+    let pre_commit = test_repo.path.join(".git/hooks/pre-commit");
+    fs::write(
+        &pre_commit,
+        format!("#!/usr/bin/env sh\n# {MANAGED_FILE_MARKER}\n/old/git-smee --config old.toml run pre-commit\n"),
+    )
+    .unwrap();
+    let pre_push = test_repo.path.join(".git/hooks/pre-push");
+    fs::write(
+        &pre_push,
+        format!("#!/usr/bin/env sh\n# {MANAGED_FILE_MARKER}\n/old/git-smee --config old.toml run pre-push\n"),
+    )
+    .unwrap();
+
+    Command::new(cargo::cargo_bin!("git-smee"))
+        .current_dir(&test_repo.path)
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("git-smee doctor: Warning")
+                .and(predicate::str::contains(
+                    "stale managed wrapper for pre-commit",
+                ))
+                .and(predicate::str::contains("run git smee install"))
+                .and(predicate::str::contains("errors:\n  - none")),
+        );
+}
+
+#[test]
 fn given_bare_repo_when_install_then_hooks_are_present() {
     let bare_repo = TempDir::new().expect("failed to create bare repo temp dir");
     git2::Repository::init_bare(bare_repo.path()).expect("failed to init bare repo");


### PR DESCRIPTION
## Summary

Closes #143.

- add `git smee doctor [--json]` with human-readable ok/warnings/errors sections and stable JSON output
- diagnose repository root, effective hooks directory, config parsing/validation, missing wrappers, unmanaged hook collisions, custom `core.hooksPath`, and stale managed wrapper paths
- document when to run doctor in the README

## Test plan

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`

## Notes

The doctor command exits non-zero only when errors are present; warning-only reports succeed so automation can distinguish drift from blocking setup problems.
