### PR TITLE
ci(release): smoke test packaged artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,28 @@ jobs:
           "asset=$asset" >> $env:GITHUB_OUTPUT
           "checksum=$asset.sha256" >> $env:GITHUB_OUTPUT
 
+      # Verify the archive we are about to publish, not just the build output.
+      - name: Smoke test Unix release archive
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          mkdir -p smoke-test
+          tar -xzf "${{ steps.package-unix.outputs.asset }}" -C smoke-test
+          test -x smoke-test/git-smee
+          smoke-test/git-smee --version
+
+      # Verify the archive we are about to publish, not just the build output.
+      - name: Smoke test Windows release archive
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path smoke-test | Out-Null
+          Expand-Archive -Path "${{ steps.package-windows.outputs.asset }}" -DestinationPath smoke-test -Force
+          if (-not (Test-Path "smoke-test/git-smee.exe")) {
+            throw "missing packaged git-smee.exe"
+          }
+          & "smoke-test/git-smee.exe" --version
+
       - name: Upload Unix release assets
         if: runner.os != 'Windows'
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,9 +128,11 @@ jobs:
       - name: Smoke test Unix release archive
         if: runner.os != 'Windows'
         shell: bash
+        env:
+          ASSET: ${{ steps.package-unix.outputs.asset }}
         run: |
           mkdir -p smoke-test
-          tar -xzf "${{ steps.package-unix.outputs.asset }}" -C smoke-test
+          tar -xzf "$ASSET" -C smoke-test
           test -x smoke-test/git-smee
           smoke-test/git-smee --version
 
@@ -138,9 +140,11 @@ jobs:
       - name: Smoke test Windows release archive
         if: runner.os == 'Windows'
         shell: pwsh
+        env:
+          ASSET: ${{ steps.package-windows.outputs.asset }}
         run: |
           New-Item -ItemType Directory -Force -Path smoke-test | Out-Null
-          Expand-Archive -Path "${{ steps.package-windows.outputs.asset }}" -DestinationPath smoke-test -Force
+          Expand-Archive -Path $env:ASSET -DestinationPath smoke-test -Force
           if (-not (Test-Path "smoke-test/git-smee.exe")) {
             throw "missing packaged git-smee.exe"
           }


### PR DESCRIPTION
## Summary
- Add release-job smoke tests that extract the packaged Unix `.tar.gz` and Windows `.zip` artifacts before upload.
- Execute the packaged `git-smee --version` binary from the extracted archive so packaging/layout/permission regressions fail before asset publication.

Closes #142

## Validation
- `python3` structural check verified smoke steps are between packaging and upload steps.
- `python3`/PyYAML parsed `.github/workflows/release.yml` and confirmed smoke steps are present.
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`
- Local Unix release packaging simulation: built `--release --locked -p git-smee-cli --target x86_64-unknown-linux-gnu`, archived `dist/git-smee`, extracted it, checked executable bit, and ran `smoke-test/git-smee --version` (`git-smee 0.0.1`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release process with automated smoke tests to verify packaged releases function correctly on both Unix and Windows platforms before publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->