### PR TITLE
Fail stale installed hook wrappers deterministically

### DIFF
--- a/crates/git-smee-core/src/installer.rs
+++ b/crates/git-smee-core/src/installer.rs
@@ -782,6 +782,26 @@ mod tests {
         );
     }
 
+    #[test]
+    fn unix_hook_template_does_not_fall_back_to_path_when_embedded_binary_is_stale() {
+        let template = Platform::Unix.hook_script_template();
+
+        assert!(!template.contains("command -v git-smee"));
+        assert!(!template.contains("git-smee --config"));
+        assert!(!template.contains("git smee --config"));
+        assert!(template.contains("embedded git-smee executable is not available"));
+    }
+
+    #[test]
+    fn windows_hook_template_does_not_fall_back_to_path_when_embedded_binary_is_stale() {
+        let template = Platform::Windows.hook_script_template();
+
+        assert!(!template.contains("where git-smee"));
+        assert!(!template.contains("git-smee --config"));
+        assert!(!template.contains("git smee --config"));
+        assert!(template.contains("embedded git-smee executable is not available"));
+    }
+
     #[cfg(unix)]
     #[test]
     fn given_special_paths_when_installing_hooks_then_unix_hook_contains_escaped_values() {

--- a/crates/git-smee-core/src/scripts/hook_template_unix
+++ b/crates/git-smee-core/src/scripts/hook_template_unix
@@ -7,10 +7,10 @@ set -e
 GIT_SMEE_BIN={git_smee_executable}
 GIT_SMEE_CONFIG={config_path}
 
-if [ -x "$GIT_SMEE_BIN" ]; then
-  "$GIT_SMEE_BIN" --config "$GIT_SMEE_CONFIG" run {hook} "$@"
-elif command -v git-smee >/dev/null 2>&1; then
-  git-smee --config "$GIT_SMEE_CONFIG" run {hook} "$@"
-else
-  git smee --config "$GIT_SMEE_CONFIG" run {hook} "$@"
+if [ ! -x "$GIT_SMEE_BIN" ]; then
+  echo "git-smee: embedded git-smee executable is not available: $GIT_SMEE_BIN" >&2
+  echo "git-smee: run 'git smee install' again to refresh this hook wrapper." >&2
+  exit 127
 fi
+
+"$GIT_SMEE_BIN" --config "$GIT_SMEE_CONFIG" run {hook} "$@"

--- a/crates/git-smee-core/src/scripts/hook_template_windows
+++ b/crates/git-smee-core/src/scripts/hook_template_windows
@@ -5,13 +5,10 @@ REM THIS FILE IS MANAGED BY git-smee
 set "GIT_SMEE_BIN={git_smee_executable}"
 set "GIT_SMEE_CONFIG={config_path}"
 
-if exist "%GIT_SMEE_BIN%" (
-  "%GIT_SMEE_BIN%" --config "%GIT_SMEE_CONFIG%" run {hook} %*
-) else (
-  where git-smee >nul 2>nul
-  if errorlevel 1 (
-    git smee --config "%GIT_SMEE_CONFIG%" run {hook} %*
-  ) else (
-    git-smee --config "%GIT_SMEE_CONFIG%" run {hook} %*
-  )
+if not exist "%GIT_SMEE_BIN%" (
+  echo git-smee: embedded git-smee executable is not available: "%GIT_SMEE_BIN%" 1>&2
+  echo git-smee: run "git smee install" again to refresh this hook wrapper. 1>&2
+  exit /b 127
 )
+
+"%GIT_SMEE_BIN%" --config "%GIT_SMEE_CONFIG%" run {hook} %*

--- a/crates/git-smee-core/tests/installer_integration.rs
+++ b/crates/git-smee-core/tests/installer_integration.rs
@@ -6,7 +6,9 @@ use std::{
 
 use git_smee_core::{
     DEFAULT_CONFIG_FILE_NAME, SmeeConfig,
-    installer::{self, Error, FileSystemHookInstaller, HookInstaller, MANAGED_FILE_MARKER},
+    installer::{
+        self, Error, FileSystemHookInstaller, HookInstaller, HookScriptOptions, MANAGED_FILE_MARKER,
+    },
 };
 
 #[test]
@@ -28,6 +30,56 @@ fn given_standard_repo_when_installing_hooks_then_hooks_are_written_to_git_hooks
     );
     assert!(hooks_path.join("pre-commit").exists());
     assert!(hooks_path.join("pre-push").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn given_stale_embedded_binary_when_running_installed_hook_then_path_fallback_is_not_used() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repo = temp_dir.path().join("repo");
+    init_repo(&repo);
+    write_config_fixture(&repo);
+
+    let fake_path_bin = temp_dir.path().join("path-bin");
+    fs::create_dir(&fake_path_bin).unwrap();
+    let fallback_marker = temp_dir.path().join("fallback-used");
+    let fallback = fake_path_bin.join("git-smee");
+    fs::write(
+        &fallback,
+        format!("#!/usr/bin/env sh\ntouch '{}'\n", fallback_marker.display()),
+    )
+    .unwrap();
+    let mut perms = fs::metadata(&fallback).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&fallback, perms).unwrap();
+
+    let missing_git_smee = temp_dir.path().join("missing").join("git-smee");
+    let config = read_config_from_repo(&repo);
+    let installer = FileSystemHookInstaller::from_path(repo.clone()).unwrap();
+    let options = HookScriptOptions::new(
+        missing_git_smee.clone(),
+        repo.join(DEFAULT_CONFIG_FILE_NAME),
+    );
+    installer::install_hooks_with_options(&config, &installer, &options).unwrap();
+
+    let original_path = std::env::var_os("PATH").unwrap_or_default();
+    let test_path = std::env::join_paths(
+        std::iter::once(fake_path_bin.clone()).chain(std::env::split_paths(&original_path)),
+    )
+    .unwrap();
+    let output = Command::new(resolve_hooks_path_with_git(&repo).join("pre-commit"))
+        .env("PATH", test_path)
+        .current_dir(&repo)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(127));
+    assert!(!fallback_marker.exists());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("embedded git-smee executable is not available"));
+    assert!(stderr.contains(&missing_git_smee.to_string_lossy().to_string()));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- remove PATH fallback from generated Unix and Windows hook wrappers when the embedded `git-smee` executable is missing
- emit an actionable reinstall error and exit non-zero instead of silently running another binary
- add template regression coverage plus a Unix integration test proving PATH fallback is not invoked

Fixes #130

## Validation
- RED: `cargo test -p git-smee-core hook_template_does_not_fall_back -- --nocapture` failed before implementation because templates still used `command -v` / `where git-smee` fallbacks.
- GREEN: `cargo test -p git-smee-core stale_embedded_binary -- --nocapture`
- GREEN: `cargo test -p git-smee-core hook_template_does_not_fall_back -- --nocapture`
- GREEN: `cargo fmt --all -- --check`
- GREEN: `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- GREEN: `cargo test --workspace --all-targets --all-features`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Git hooks now strictly require the embedded executable without falling back to PATH. When missing, hooks display an error and exit with status code 127, directing users to re-run installation.

* **Tests**
  * Added unit tests validating hook scripts do not use PATH fallback.
  * Added integration test for Unix hook behavior with missing embedded executable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->