### PR TITLE
Prune obsolete managed hooks on install

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ cargo install --path crates/git-smee-cli
 
    By default, `install` only overwrites hook files previously managed by git-smee.
    Existing unmanaged hook files are preserved unless you pass `--force`.
+   When a hook phase is removed from `.git-smee.toml`, `install` also prunes
+   the now-obsolete managed wrapper for that phase so stale hooks do not keep
+   running; unmanaged files for removed phases are left untouched.
    If the repository uses `core.hooksPath` and that directory does not exist yet,
    `install` creates the effective hooks directory before writing managed wrappers.
 

--- a/crates/git-smee-core/src/installer.rs
+++ b/crates/git-smee-core/src/installer.rs
@@ -1,4 +1,4 @@
-use crate::{DEFAULT_CONFIG_FILE_NAME, SmeeConfig, platform::Platform};
+use crate::{DEFAULT_CONFIG_FILE_NAME, SmeeConfig, config::LifeCyclePhase, platform::Platform};
 use std::{
     fs,
     io::Read,
@@ -68,6 +68,12 @@ pub enum Error {
         #[source]
         source: std::io::Error,
     },
+    #[error("Failed to remove obsolete managed hook '{path}': {source}")]
+    FailedToRemoveObsoleteHook {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
     #[error("Failed to write config file '{path}': {source}")]
     FailedToWriteConfigFile {
         path: String,
@@ -118,6 +124,11 @@ pub enum Error {
 pub trait HookInstaller {
     fn install_hook(&self, hook_name: &str, hook_content: &str) -> Result<PathBuf, Error>;
     fn install_config_file(&self, config_content: &str) -> Result<PathBuf, Error>;
+
+    fn prune_obsolete_hooks(&self, active_hook_names: &[String]) -> Result<(), Error> {
+        let _ = active_hook_names;
+        Ok(())
+    }
 }
 
 pub struct FileSystemHookInstaller {
@@ -313,6 +324,29 @@ impl FileSystemHookInstaller {
     fn ensure_can_write_config(&self, config_file: &Path) -> Result<(), Error> {
         ensure_can_write_config_file(config_file, self.force_overwrite)
     }
+
+    fn prune_obsolete_managed_hook(
+        &self,
+        hook_name: &str,
+        active_hook_names: &[String],
+    ) -> Result<(), Error> {
+        if active_hook_names
+            .iter()
+            .any(|active_hook| active_hook == hook_name)
+        {
+            return Ok(());
+        }
+
+        let hook_file = self.hooks_dir.join(hook_name);
+        if !hook_file.exists() || !is_managed_file(&hook_file)? {
+            return Ok(());
+        }
+
+        fs::remove_file(&hook_file).map_err(|source| Error::FailedToRemoveObsoleteHook {
+            path: hook_file.to_string_lossy().to_string(),
+            source,
+        })
+    }
 }
 
 impl HookInstaller for FileSystemHookInstaller {
@@ -336,6 +370,13 @@ impl HookInstaller for FileSystemHookInstaller {
             }
         })?;
         Ok(config_path)
+    }
+
+    fn prune_obsolete_hooks(&self, active_hook_names: &[String]) -> Result<(), Error> {
+        for phase in LifeCyclePhase::all() {
+            self.prune_obsolete_managed_hook(phase.as_str(), active_hook_names)?;
+        }
+        Ok(())
     }
 }
 
@@ -476,6 +517,7 @@ pub fn install_hooks_with_options<T: HookInstaller>(
     };
     let mut phases: Vec<_> = config.hooks.keys().copied().collect();
     phases.sort_by_key(|phase| phase.as_str());
+    let active_hook_names: Vec<_> = phases.iter().map(|phase| phase.to_string()).collect();
     phases
         .into_iter()
         .map(|life_cycle_phase| {
@@ -493,6 +535,7 @@ pub fn install_hooks_with_options<T: HookInstaller>(
             Ok(())
         })
         .collect::<Result<Vec<_>, Error>>()?;
+    hook_installer.prune_obsolete_hooks(&active_hook_names)?;
     Ok(())
 }
 

--- a/crates/git-smee-core/tests/installer_integration.rs
+++ b/crates/git-smee-core/tests/installer_integration.rs
@@ -277,6 +277,48 @@ fn given_managed_existing_hook_when_installing_without_force_then_it_is_overwrit
 }
 
 #[test]
+fn given_managed_hook_phase_removed_when_reinstalling_then_obsolete_hook_is_pruned() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repo = temp_dir.path().join("repo");
+    init_repo(&repo);
+    write_config_fixture(&repo);
+
+    let full_config = read_config_from_repo(&repo);
+    let installer = FileSystemHookInstaller::from_path(repo.clone()).unwrap();
+    installer::install_hooks(&full_config, &installer).unwrap();
+
+    let hooks_path = resolve_hooks_path_with_git(&repo);
+    let pre_commit = hooks_path.join("pre-commit");
+    let pre_push = hooks_path.join("pre-push");
+    assert!(pre_commit.exists());
+    assert!(pre_push.exists());
+
+    let config_without_pre_push = pre_commit_only_config();
+    installer::install_hooks(&config_without_pre_push, &installer).unwrap();
+
+    assert!(pre_commit.exists());
+    assert!(!pre_push.exists());
+}
+
+#[test]
+fn given_unmanaged_hook_for_removed_phase_when_reinstalling_then_hook_is_preserved() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repo = temp_dir.path().join("repo");
+    init_repo(&repo);
+
+    let hooks_path = resolve_hooks_path_with_git(&repo);
+    let pre_push = hooks_path.join("pre-push");
+    let unmanaged_content = "#!/usr/bin/env sh\necho 'custom pre-push'\n";
+    fs::write(&pre_push, unmanaged_content).unwrap();
+
+    let config_without_pre_push = pre_commit_only_config();
+    let installer = FileSystemHookInstaller::from_path(repo.clone()).unwrap();
+    installer::install_hooks(&config_without_pre_push, &installer).unwrap();
+
+    assert_eq!(fs::read_to_string(pre_push).unwrap(), unmanaged_content);
+}
+
+#[test]
 fn given_managed_marker_after_shebang_and_blank_line_when_installing_then_it_is_overwritten() {
     let temp_dir = tempfile::tempdir().unwrap();
     let repo = temp_dir.path().join("repo");
@@ -498,6 +540,18 @@ fn write_config_fixture(repo: &Path) {
     let config_content = fs::read_to_string("tests/fixtures/simple_git-smee_config.toml")
         .expect("Should read fixture file");
     fs::write(repo.join(DEFAULT_CONFIG_FILE_NAME), config_content).unwrap();
+}
+
+fn pre_commit_only_config() -> SmeeConfig {
+    let mut hooks = std::collections::HashMap::new();
+    hooks.insert(
+        git_smee_core::config::LifeCyclePhase::PreCommit,
+        vec![git_smee_core::config::HookDefinition {
+            command: "echo pre-commit".to_string(),
+            parallel_execution_allowed: false,
+        }],
+    );
+    SmeeConfig { hooks }
 }
 
 fn read_config_from_repo(repo: &Path) -> SmeeConfig {


### PR DESCRIPTION
## Summary
- Prune obsolete git-smee-managed hook wrappers when `git smee install` is rerun after a phase is removed from config.
- Preserve unmanaged hook files for removed phases.
- Document install-time pruning semantics in the README.

Fixes #134

## Test plan
- RED: `cargo test -p git-smee-core --test installer_integration given_managed_hook_phase_removed_when_reinstalling_then_obsolete_hook_is_pruned -- --nocapture` failed before implementation with stale `pre-push` still present.
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `git smee install` now automatically removes previously installed managed hooks when the corresponding phase is removed from configuration, while preserving any unmanaged hook files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->