### PR TITLE
Make hook install preflight target writes

### DIFF
--- a/crates/git-smee-core/src/installer.rs
+++ b/crates/git-smee-core/src/installer.rs
@@ -122,6 +122,11 @@ pub enum Error {
 /// The trait defines a rough shape for anything that might install a hook. However the most common implementation
 /// will be a [`FileSystemHookInstaller`]
 pub trait HookInstaller {
+    fn prepare_install_hooks(&self, hook_names: &[String]) -> Result<(), Error> {
+        let _ = hook_names;
+        Ok(())
+    }
+
     fn install_hook(&self, hook_name: &str, hook_content: &str) -> Result<PathBuf, Error>;
     fn install_config_file(&self, config_content: &str) -> Result<PathBuf, Error>;
 
@@ -350,6 +355,14 @@ impl FileSystemHookInstaller {
 }
 
 impl HookInstaller for FileSystemHookInstaller {
+    fn prepare_install_hooks(&self, hook_names: &[String]) -> Result<(), Error> {
+        for hook_name in hook_names {
+            let hook_file = self.hooks_dir.join(hook_name);
+            self.ensure_can_write_hook(&hook_file)?;
+        }
+        Ok(())
+    }
+
     fn install_hook(&self, hook_name: &str, hook_content: &str) -> Result<PathBuf, Error> {
         let hook_file = self.hooks_dir.join(hook_name);
         self.ensure_can_write_hook(&hook_file)?;
@@ -518,6 +531,7 @@ pub fn install_hooks_with_options<T: HookInstaller>(
     let mut phases: Vec<_> = config.hooks.keys().copied().collect();
     phases.sort_by_key(|phase| phase.as_str());
     let active_hook_names: Vec<_> = phases.iter().map(|phase| phase.to_string()).collect();
+    hook_installer.prepare_install_hooks(&active_hook_names)?;
     phases
         .into_iter()
         .map(|life_cycle_phase| {

--- a/crates/git-smee-core/tests/installer_integration.rs
+++ b/crates/git-smee-core/tests/installer_integration.rs
@@ -232,6 +232,35 @@ fn given_unmanaged_existing_hook_when_installing_without_force_then_error_and_fi
 }
 
 #[test]
+fn given_later_unmanaged_hook_when_installing_without_force_then_no_earlier_hooks_are_written() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repo = temp_dir.path().join("repo");
+    init_repo(&repo);
+    fs::write(
+        repo.join(DEFAULT_CONFIG_FILE_NAME),
+        "[[applypatch-msg]]\ncommand = \"echo one\"\n\n[[pre-commit]]\ncommand = \"echo two\"\n",
+    )
+    .unwrap();
+
+    let hooks_path = resolve_hooks_path_with_git(&repo);
+    let applypatch_msg = hooks_path.join("applypatch-msg");
+    let pre_commit = hooks_path.join("pre-commit");
+    let unmanaged_content = "#!/usr/bin/env sh\necho 'custom unmanaged hook'\n";
+    fs::write(&pre_commit, unmanaged_content).unwrap();
+
+    let config = read_config_from_repo(&repo);
+    let installer = FileSystemHookInstaller::from_path(repo.clone()).unwrap();
+    let result = installer::install_hooks(&config, &installer);
+
+    assert!(matches!(
+        result,
+        Err(Error::RefusingToOverwriteUnmanagedHookFile { .. })
+    ));
+    assert!(!applypatch_msg.exists());
+    assert_eq!(fs::read_to_string(pre_commit).unwrap(), unmanaged_content);
+}
+
+#[test]
 fn given_hook_with_marker_only_in_body_when_installing_without_force_then_treated_as_unmanaged() {
     let temp_dir = tempfile::tempdir().unwrap();
     let repo = temp_dir.path().join("repo");


### PR DESCRIPTION
## Summary
- Adds a preflight hook-install phase so filesystem installs validate every target before writing any hook.
- Keeps the generic `HookInstaller` trait default no-op for non-filesystem/test installers.
- Adds a regression test for the mixed target case where an earlier hook must not be written if a later unmanaged hook blocks install.

Fixes #133

## Validation
- RED: `cargo test -p git-smee-core given_later_unmanaged_hook_when_installing_without_force_then_no_earlier_hooks_are_written -- --nocapture` failed before the fix because `applypatch-msg` was written before `pre-commit` failed.
- GREEN: `cargo test -p git-smee-core given_later_unmanaged_hook_when_installing_without_force_then_no_earlier_hooks_are_written -- --nocapture`
- GREEN: `cargo test -p git-smee-core installer::tests::given_multiple_hooks_when_installing_hooks_then_all_hooks_installed -- --nocapture`
- GREEN: `cargo fmt --all -- --check`
- GREEN: `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- GREEN: `cargo test --workspace --all-targets --all-features`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hook installation now includes pre-flight validation that checks if hook files can be written before installation begins, preventing partial installations and providing clearer error messages when conflicts are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->