### PR TITLE
Refuse symlink targets for managed writes

### DIFF
--- a/crates/git-smee-core/src/installer.rs
+++ b/crates/git-smee-core/src/installer.rs
@@ -103,6 +103,10 @@ pub enum Error {
         "Refusing to overwrite existing managed config file '{path}'. Re-run with --force to overwrite."
     )]
     RefusingToOverwriteManagedConfigFile { path: String },
+    #[error(
+        "Refusing to write managed file through symlink '{path}'. Remove the symlink and retry."
+    )]
+    RefusingToWriteSymlink { path: String },
     #[error("Failed to read existing file '{path}' while checking managed marker: {source}")]
     FailedToReadExistingFile {
         path: String,
@@ -300,6 +304,8 @@ impl FileSystemHookInstaller {
         config_file: &Path,
         force_overwrite: bool,
     ) -> Result<(), Error> {
+        ensure_not_symlink(config_file)?;
+
         if !config_file.exists() || force_overwrite {
             return Ok(());
         }
@@ -313,6 +319,8 @@ impl FileSystemHookInstaller {
     }
 
     fn ensure_can_write_hook(&self, hook_file: &Path) -> Result<(), Error> {
+        ensure_not_symlink(hook_file)?;
+
         if !hook_file.exists() || self.force_overwrite {
             return Ok(());
         }
@@ -416,6 +424,8 @@ pub fn write_config_file(
 }
 
 fn ensure_can_write_config_file(config_file: &Path, force_overwrite: bool) -> Result<(), Error> {
+    ensure_not_symlink(config_file)?;
+
     if config_file.exists() && !config_file.is_file() {
         return Err(Error::ConfigPathNotAFile {
             path: config_file.to_string_lossy().to_string(),
@@ -432,6 +442,20 @@ fn ensure_can_write_config_file(config_file: &Path, force_overwrite: bool) -> Re
     }
 
     Err(Error::RefusingToOverwriteUnmanagedConfigFile { path })
+}
+
+fn ensure_not_symlink(path: &Path) -> Result<(), Error> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(Error::RefusingToWriteSymlink {
+            path: path.to_string_lossy().to_string(),
+        }),
+        Ok(_) => Ok(()),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(Error::FailedToReadExistingFile {
+            path: path.to_string_lossy().to_string(),
+            source,
+        }),
+    }
 }
 
 fn is_managed_file(path: &Path) -> Result<bool, Error> {

--- a/crates/git-smee-core/tests/installer_integration.rs
+++ b/crates/git-smee-core/tests/installer_integration.rs
@@ -479,6 +479,30 @@ fn given_unmanaged_existing_hook_when_installing_with_force_then_it_is_overwritt
     assert!(installed.contains("run pre-commit"));
 }
 
+#[cfg(unix)]
+#[test]
+fn given_hook_path_is_symlink_when_installing_with_force_then_refuses_and_target_unchanged() {
+    use std::os::unix::fs::symlink;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repo = temp_dir.path().join("repo");
+    init_repo(&repo);
+    write_config_fixture(&repo);
+
+    let outside_target = temp_dir.path().join("outside-hook-target");
+    let outside_content = "outside target must not be overwritten\n";
+    fs::write(&outside_target, outside_content).unwrap();
+    let pre_commit = resolve_hooks_path_with_git(&repo).join("pre-commit");
+    symlink(&outside_target, &pre_commit).unwrap();
+
+    let config = read_config_from_repo(&repo);
+    let installer = FileSystemHookInstaller::from_path_with_force(repo.clone(), true).unwrap();
+    let result = installer::install_hooks(&config, &installer);
+
+    assert!(matches!(result, Err(Error::RefusingToWriteSymlink { .. })));
+    assert_eq!(fs::read_to_string(outside_target).unwrap(), outside_content);
+}
+
 #[test]
 fn given_existing_config_when_initializing_without_force_then_refuses_overwrite() {
     let temp_dir = tempfile::tempdir().unwrap();
@@ -558,6 +582,28 @@ fn given_existing_config_when_initializing_with_force_then_overwrites() {
 
     let updated = fs::read_to_string(config_path).unwrap();
     assert!(updated.contains("echo default"));
+}
+
+#[cfg(unix)]
+#[test]
+fn given_config_path_is_symlink_when_initializing_with_force_then_refuses_and_target_unchanged() {
+    use std::os::unix::fs::symlink;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repo = temp_dir.path().join("repo");
+    init_repo(&repo);
+
+    let outside_target = temp_dir.path().join("outside-config-target.toml");
+    let outside_content = "[[pre-commit]]\ncommand = \"echo outside\"\n";
+    fs::write(&outside_target, outside_content).unwrap();
+    let config_path = repo.join(DEFAULT_CONFIG_FILE_NAME);
+    symlink(&outside_target, &config_path).unwrap();
+
+    let installer = FileSystemHookInstaller::from_path_with_force(repo.clone(), true).unwrap();
+    let result = installer.install_config_file("[[pre-commit]]\ncommand = \"echo default\"\n");
+
+    assert!(matches!(result, Err(Error::RefusingToWriteSymlink { .. })));
+    assert_eq!(fs::read_to_string(outside_target).unwrap(), outside_content);
 }
 
 fn init_repo(repo: &Path) {


### PR DESCRIPTION
## Summary
- refuse managed hook/config writes when the destination path is a symlink, even with `--force`
- reuse the guard for default init, custom config writes, and hook install preflight/install paths
- add Unix regression coverage proving external symlink targets stay unchanged

Fixes #124

## Validation
- RED: `cargo test -p git-smee-core symlink -- --nocapture` failed before implementation with missing `RefusingToWriteSymlink` behavior
- GREEN: `cargo test -p git-smee-core symlink -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented managed hook and config files from being written through symlink paths, protecting file integrity and preventing accidental overwrites.

* **Tests**
  * Added integration tests to validate symlink-handling behavior in hook and config file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->