### PR TITLE
feat(cli): add hook status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,8 +235,32 @@ protocol handshake before the command starts.
 git smee init [--force] [--config <path>]       # Initialize a config file
 git smee install [--force] [--config <path>]    # Install hooks from the selected config
 git smee [--config <path>] run <hook> [hook-args...]           # Run a specific git hook
+git smee [--config <path>] status [--json]      # Show hook coverage and drift
 git smee [--config <path>] doctor [--json]      # Diagnose repository setup and hook drift
 ```
+
+Run `git smee status` as a read-only onboarding or CI smoke check after editing
+`.git-smee.toml` or reinstalling wrappers. It summarizes each configured phase,
+command counts, missing/unmanaged/stale wrappers, obsolete managed wrappers, and
+next actions. For example:
+
+```text
+git-smee status: Drift
+configured hooks:
+  - pre-commit: configured commands=1, installed (.git/hooks/pre-commit)
+  - pre-push: configured commands=1, missing (.git/hooks/pre-push)
+    next: run git smee install to create pre-push
+obsolete managed hooks:
+  - commit-msg: obsolete managed wrapper (.git/hooks/commit-msg)
+    next: remove obsolete managed hook .git/hooks/commit-msg
+next actions:
+  - remove obsolete managed hook .git/hooks/commit-msg
+  - run git smee install to create pre-push
+```
+
+Use `git smee status --json` when tooling needs stable fields such as `status`,
+`hooks[].configured_command_count`, `hooks[].state`, `obsolete_managed_hooks`, and
+`next_actions`.
 
 Run `git smee doctor` when onboarding a repository, after changing `core.hooksPath`, or when a
 hook does not fire as expected. The human-readable report groups `ok`, `warnings`, and `errors`

--- a/crates/git-smee-cli/src/main.rs
+++ b/crates/git-smee-cli/src/main.rs
@@ -227,33 +227,42 @@ fn build_status_report(config_path: &Path) -> Result<StatusReport, Box<dyn std::
                 )),
             )
         } else {
-            match fs::read_to_string(&hook_path) {
-                Ok(content) if !content.contains(MANAGED_FILE_MARKER) => (
+            match installer::has_managed_header(&hook_path) {
+                Ok(false) => (
                     HookState::Unmanaged,
                     Some(format!(
                         "move {} aside or run git smee install --force",
                         display_repo_path(&repository_root, &hook_path)
                     )),
                 ),
-                Ok(content) => {
-                    if !content.contains(&expected_config) {
-                        stale_reasons.push(format!("expected config path {expected_config}"));
-                    }
-                    if let Some(expected_exe) = &expected_exe {
-                        let expected_exe = expected_exe.to_string_lossy().to_string();
-                        if !content.contains(&expected_exe) {
-                            stale_reasons.push(format!("expected executable {expected_exe}"));
+                Ok(true) => match fs::read_to_string(&hook_path) {
+                    Ok(content) => {
+                        if !content.contains(&expected_config) {
+                            stale_reasons.push(format!("expected config path {expected_config}"));
+                        }
+                        if let Some(expected_exe) = &expected_exe {
+                            let expected_exe = expected_exe.to_string_lossy().to_string();
+                            if !content.contains(&expected_exe) {
+                                stale_reasons.push(format!("expected executable {expected_exe}"));
+                            }
+                        }
+                        if stale_reasons.is_empty() {
+                            (HookState::Installed, None)
+                        } else {
+                            (
+                                HookState::Stale,
+                                Some(format!("run git smee install to refresh {phase}")),
+                            )
                         }
                     }
-                    if stale_reasons.is_empty() {
-                        (HookState::Installed, None)
-                    } else {
-                        (
-                            HookState::Stale,
-                            Some(format!("run git smee install to refresh {phase}")),
-                        )
-                    }
-                }
+                    Err(error) => (
+                        HookState::Unreadable,
+                        Some(format!(
+                            "fix permissions for {} ({error})",
+                            display_repo_path(&repository_root, &hook_path)
+                        )),
+                    ),
+                },
                 Err(error) => (
                     HookState::Unreadable,
                     Some(format!(
@@ -287,10 +296,10 @@ fn build_status_report(config_path: &Path) -> Result<StatusReport, Box<dyn std::
         if !hook_path.is_file() {
             continue;
         }
-        let Ok(content) = fs::read_to_string(&hook_path) else {
+        let Ok(is_managed) = installer::has_managed_header(&hook_path) else {
             continue;
         };
-        if content.contains(MANAGED_FILE_MARKER) {
+        if is_managed {
             let path = display_repo_path(&repository_root, &hook_path);
             let next_action = format!("remove obsolete managed hook {path}");
             next_actions.push(next_action.clone());
@@ -323,7 +332,7 @@ fn build_status_report(config_path: &Path) -> Result<StatusReport, Box<dyn std::
 }
 
 fn print_status_report(report: &StatusReport) {
-    println!("git-smee status: {:?}", report.status);
+    println!("git-smee status: {}", report.status.as_text());
     println!("repository root: {}", report.repository_root);
     println!("hooks directory: {}", report.hooks_dir);
     println!("config path: {}", report.config_path);
@@ -371,6 +380,15 @@ impl HookState {
             HookState::Stale => "stale",
             HookState::Unreadable => "unreadable",
             HookState::InvalidPath => "invalid path",
+        }
+    }
+}
+
+impl StatusState {
+    fn as_text(&self) -> &'static str {
+        match self {
+            StatusState::Ok => "Ok",
+            StatusState::Drift => "Drift",
         }
     }
 }

--- a/crates/git-smee-cli/src/main.rs
+++ b/crates/git-smee-cli/src/main.rs
@@ -380,6 +380,7 @@ fn display_repo_path(repository_root: &Path, path: &Path) -> String {
         .unwrap_or(path)
         .display()
         .to_string()
+        .replace('\\', "/")
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/git-smee-cli/src/main.rs
+++ b/crates/git-smee-cli/src/main.rs
@@ -61,6 +61,11 @@ enum Command {
         #[arg(long, help = "Emit a stable JSON diagnostics report")]
         json: bool,
     },
+    #[command(name = "status", about = "Show installed hook coverage and drift")]
+    Status {
+        #[arg(long, help = "Emit a stable JSON status report")]
+        json: bool,
+    },
 }
 
 fn main() {
@@ -126,7 +131,255 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             Ok(())
         }
         Command::Doctor { json } => run_doctor(&config_path, json),
+        Command::Status { json } => run_status(&config_path, json),
     }
+}
+
+#[derive(Debug, Serialize)]
+struct StatusReport {
+    status: StatusState,
+    repository_root: String,
+    hooks_dir: String,
+    config_path: String,
+    hooks: Vec<HookStatus>,
+    obsolete_managed_hooks: Vec<ObsoleteHookStatus>,
+    next_actions: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum StatusState {
+    Ok,
+    Drift,
+}
+
+#[derive(Debug, Serialize)]
+struct HookStatus {
+    phase: String,
+    configured_command_count: usize,
+    state: HookState,
+    path: String,
+    stale_reasons: Vec<String>,
+    next_action: Option<String>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+enum HookState {
+    Installed,
+    Missing,
+    Unmanaged,
+    Stale,
+    Unreadable,
+    InvalidPath,
+}
+
+#[derive(Debug, Serialize)]
+struct ObsoleteHookStatus {
+    phase: String,
+    path: String,
+    next_action: String,
+}
+
+fn run_status(config_path: &Path, json: bool) -> Result<(), Box<dyn std::error::Error>> {
+    repository::ensure_in_repo_root()?;
+    let report = build_status_report(config_path)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print_status_report(&report);
+    }
+    Ok(())
+}
+
+fn build_status_report(config_path: &Path) -> Result<StatusReport, Box<dyn std::error::Error>> {
+    let repository_root = repository::find_git_root()?;
+    let hooks_dir = repository::resolve_git_path(
+        &repository_root,
+        installer::FileSystemHookInstaller::HOOKS_GIT_PATH_KEY,
+    )?;
+    let config = read_config_file(config_path)?;
+    let expected_config_path = normalize_config_path_for_hook_script(config_path, &repository_root)
+        .unwrap_or_else(|_| config_path.to_path_buf());
+    let expected_exe = env::current_exe().ok();
+    let expected_config = expected_config_path.to_string_lossy().to_string();
+
+    let mut phases: Vec<_> = config.hooks.keys().copied().collect();
+    phases.sort_by_key(|phase| phase.as_str());
+
+    let mut hooks = Vec::new();
+    let mut next_actions = Vec::new();
+    for phase in &phases {
+        let hook_path = hooks_dir.join(phase.as_str());
+        let configured_command_count = config.hooks.get(phase).map_or(0, Vec::len);
+        let mut stale_reasons = Vec::new();
+        let (state, next_action) = if !hook_path.exists() {
+            (
+                HookState::Missing,
+                Some(format!("run git smee install to create {phase}")),
+            )
+        } else if !hook_path.is_file() {
+            (
+                HookState::InvalidPath,
+                Some(format!(
+                    "remove {} or fix core.hooksPath before reinstalling",
+                    display_repo_path(&repository_root, &hook_path)
+                )),
+            )
+        } else {
+            match fs::read_to_string(&hook_path) {
+                Ok(content) if !content.contains(MANAGED_FILE_MARKER) => (
+                    HookState::Unmanaged,
+                    Some(format!(
+                        "move {} aside or run git smee install --force",
+                        display_repo_path(&repository_root, &hook_path)
+                    )),
+                ),
+                Ok(content) => {
+                    if !content.contains(&expected_config) {
+                        stale_reasons.push(format!("expected config path {expected_config}"));
+                    }
+                    if let Some(expected_exe) = &expected_exe {
+                        let expected_exe = expected_exe.to_string_lossy().to_string();
+                        if !content.contains(&expected_exe) {
+                            stale_reasons.push(format!("expected executable {expected_exe}"));
+                        }
+                    }
+                    if stale_reasons.is_empty() {
+                        (HookState::Installed, None)
+                    } else {
+                        (
+                            HookState::Stale,
+                            Some(format!("run git smee install to refresh {phase}")),
+                        )
+                    }
+                }
+                Err(error) => (
+                    HookState::Unreadable,
+                    Some(format!(
+                        "fix permissions for {} ({error})",
+                        display_repo_path(&repository_root, &hook_path)
+                    )),
+                ),
+            }
+        };
+
+        if let Some(action) = &next_action {
+            next_actions.push(action.clone());
+        }
+        hooks.push(HookStatus {
+            phase: phase.to_string(),
+            configured_command_count,
+            state,
+            path: display_repo_path(&repository_root, &hook_path),
+            stale_reasons,
+            next_action,
+        });
+    }
+
+    let configured_phase_names: Vec<_> = phases.iter().map(|phase| phase.as_str()).collect();
+    let mut obsolete_managed_hooks = Vec::new();
+    for phase in LifeCyclePhase::all() {
+        if configured_phase_names.contains(&phase.as_str()) {
+            continue;
+        }
+        let hook_path = hooks_dir.join(phase.as_str());
+        if !hook_path.is_file() {
+            continue;
+        }
+        let Ok(content) = fs::read_to_string(&hook_path) else {
+            continue;
+        };
+        if content.contains(MANAGED_FILE_MARKER) {
+            let path = display_repo_path(&repository_root, &hook_path);
+            let next_action = format!("remove obsolete managed hook {path}");
+            next_actions.push(next_action.clone());
+            obsolete_managed_hooks.push(ObsoleteHookStatus {
+                phase: phase.to_string(),
+                path,
+                next_action,
+            });
+        }
+    }
+
+    next_actions.sort();
+    next_actions.dedup();
+
+    let status = if next_actions.is_empty() {
+        StatusState::Ok
+    } else {
+        StatusState::Drift
+    };
+
+    Ok(StatusReport {
+        status,
+        repository_root: repository_root.display().to_string(),
+        hooks_dir: hooks_dir.display().to_string(),
+        config_path: config_path.display().to_string(),
+        hooks,
+        obsolete_managed_hooks,
+        next_actions,
+    })
+}
+
+fn print_status_report(report: &StatusReport) {
+    println!("git-smee status: {:?}", report.status);
+    println!("repository root: {}", report.repository_root);
+    println!("hooks directory: {}", report.hooks_dir);
+    println!("config path: {}", report.config_path);
+    println!("configured hooks:");
+    if report.hooks.is_empty() {
+        println!("  - none");
+    } else {
+        for hook in &report.hooks {
+            println!(
+                "  - {}: configured commands={}, {} ({})",
+                hook.phase,
+                hook.configured_command_count,
+                hook.state.as_text(),
+                hook.path
+            );
+            for reason in &hook.stale_reasons {
+                println!("    stale: {reason}");
+            }
+            if let Some(action) = &hook.next_action {
+                println!("    next: {action}");
+            }
+        }
+    }
+    println!("obsolete managed hooks:");
+    if report.obsolete_managed_hooks.is_empty() {
+        println!("  - none");
+    } else {
+        for hook in &report.obsolete_managed_hooks {
+            println!(
+                "  - {}: obsolete managed wrapper ({})",
+                hook.phase, hook.path
+            );
+            println!("    next: {}", hook.next_action);
+        }
+    }
+    print_doctor_section("next actions", &report.next_actions);
+}
+
+impl HookState {
+    fn as_text(&self) -> &'static str {
+        match self {
+            HookState::Installed => "installed",
+            HookState::Missing => "missing",
+            HookState::Unmanaged => "unmanaged",
+            HookState::Stale => "stale",
+            HookState::Unreadable => "unreadable",
+            HookState::InvalidPath => "invalid path",
+        }
+    }
+}
+
+fn display_repo_path(repository_root: &Path, path: &Path) -> String {
+    path.strip_prefix(repository_root)
+        .unwrap_or(path)
+        .display()
+        .to_string()
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -135,6 +135,111 @@ fn given_healthy_repo_when_doctor_json_then_stable_json_is_reported() {
 }
 
 #[test]
+fn given_installed_hooks_when_status_then_reports_coverage() {
+    let test_repo = common::TestRepo::default();
+    Command::new(cargo::cargo_bin!("git-smee"))
+        .current_dir(&test_repo.path)
+        .arg("install")
+        .assert()
+        .success();
+
+    Command::new(cargo::cargo_bin!("git-smee"))
+        .current_dir(&test_repo.path)
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("git-smee status: Ok")
+                .and(predicate::str::contains(
+                    "pre-commit: configured commands=1, installed",
+                ))
+                .and(predicate::str::contains(
+                    "pre-push: configured commands=1, installed",
+                ))
+                .and(predicate::str::contains("next actions:\n  - none")),
+        );
+}
+
+#[test]
+fn given_missing_and_unmanaged_hooks_when_status_then_reports_next_actions() {
+    let test_repo = common::TestRepo::default();
+    let pre_commit = test_repo.path.join(".git/hooks/pre-commit");
+    fs::write(&pre_commit, "#!/usr/bin/env sh\necho unmanaged\n").unwrap();
+
+    Command::new(cargo::cargo_bin!("git-smee"))
+        .current_dir(&test_repo.path)
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("git-smee status: Drift")
+                .and(predicate::str::contains(
+                    "pre-commit: configured commands=1, unmanaged",
+                ))
+                .and(predicate::str::contains(
+                    "pre-push: configured commands=1, missing",
+                ))
+                .and(predicate::str::contains("run git smee install --force"))
+                .and(predicate::str::contains("run git smee install")),
+        );
+}
+
+#[test]
+fn given_stale_and_obsolete_managed_hooks_when_status_then_reports_drift_without_modifying() {
+    let test_repo = common::TestRepo::default();
+    let pre_commit = test_repo.path.join(".git/hooks/pre-commit");
+    fs::write(
+        &pre_commit,
+        format!("#!/usr/bin/env sh\n# {MANAGED_FILE_MARKER}\n/old/git-smee --config old.toml run pre-commit\n"),
+    )
+    .unwrap();
+    let obsolete = test_repo.path.join(".git/hooks/commit-msg");
+    fs::write(
+        &obsolete,
+        format!("#!/usr/bin/env sh\n# {MANAGED_FILE_MARKER}\n/old/git-smee run commit-msg\n"),
+    )
+    .unwrap();
+
+    Command::new(cargo::cargo_bin!("git-smee"))
+        .current_dir(&test_repo.path)
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("pre-commit: configured commands=1, stale")
+                .and(predicate::str::contains(
+                    "commit-msg: obsolete managed wrapper",
+                ))
+                .and(predicate::str::contains(
+                    "remove obsolete managed hook .git/hooks/commit-msg",
+                )),
+        );
+
+    assert!(
+        obsolete.exists(),
+        "status must not remove obsolete managed hooks"
+    );
+}
+
+#[test]
+fn given_drift_when_status_json_then_stable_json_is_reported() {
+    let test_repo = common::TestRepo::default();
+
+    Command::new(cargo::cargo_bin!("git-smee"))
+        .current_dir(&test_repo.path)
+        .args(["status", "--json"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains(r#""status": "drift""#)
+                .and(predicate::str::contains(r#""phase": "pre-commit""#))
+                .and(predicate::str::contains(r#""configured_command_count": 1"#))
+                .and(predicate::str::contains(r#""state": "missing""#))
+                .and(predicate::str::contains(r#""next_actions""#)),
+        );
+}
+
+#[test]
 fn given_missing_config_when_doctor_then_actionable_error_is_reported() {
     let test_repo = common::TestRepo::default();
     fs::remove_file(test_repo.config_path()).expect("failed to remove config");

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -222,6 +222,52 @@ fn given_stale_and_obsolete_managed_hooks_when_status_then_reports_drift_without
 }
 
 #[test]
+fn given_marker_only_in_body_when_status_then_treats_hook_as_unmanaged() {
+    let test_repo = common::TestRepo::default();
+    test_repo.write_config(
+        r#"
+        [[commit-msg]]
+        command = "echo commit message"
+        "#,
+    );
+    let commit_msg = test_repo.path.join(".git/hooks/commit-msg");
+    fs::write(
+        &commit_msg,
+        format!("#!/usr/bin/env sh\necho '{MANAGED_FILE_MARKER}'\n"),
+    )
+    .unwrap();
+
+    Command::new(cargo::cargo_bin!("git-smee"))
+        .current_dir(&test_repo.path)
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("commit-msg: configured commands=1, unmanaged")
+                .and(predicate::str::contains("obsolete managed wrapper").not())
+                .and(predicate::str::contains("run git smee install --force")),
+        );
+}
+
+#[test]
+fn given_unconfigured_marker_only_in_body_when_status_then_does_not_recommend_removal() {
+    let test_repo = common::TestRepo::default();
+    let commit_msg = test_repo.path.join(".git/hooks/commit-msg");
+    fs::write(
+        &commit_msg,
+        format!("#!/usr/bin/env sh\necho '{MANAGED_FILE_MARKER}'\n"),
+    )
+    .unwrap();
+
+    Command::new(cargo::cargo_bin!("git-smee"))
+        .current_dir(&test_repo.path)
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("obsolete managed wrapper").not());
+}
+
+#[test]
 fn given_drift_when_status_json_then_stable_json_is_reported() {
     let test_repo = common::TestRepo::default();
 

--- a/crates/git-smee-core/src/installer.rs
+++ b/crates/git-smee-core/src/installer.rs
@@ -458,6 +458,15 @@ fn ensure_not_symlink(path: &Path) -> Result<(), Error> {
     }
 }
 
+/// Returns true when a file has git-smee's managed marker in its header.
+///
+/// The marker must appear in the same header position accepted by installer
+/// overwrite/pruning logic; marker text later in a hook body is treated as
+/// user-owned content.
+pub fn has_managed_header(path: &Path) -> Result<bool, Error> {
+    is_managed_file(path)
+}
+
 fn is_managed_file(path: &Path) -> Result<bool, Error> {
     let mut file = fs::File::open(path).map_err(|source| Error::FailedToReadExistingFile {
         path: path.to_string_lossy().to_string(),


### PR DESCRIPTION
## Summary
- add read-only `git smee status [--json]` hook coverage and drift reporting
- report configured command counts, missing/unmanaged/stale wrappers, obsolete managed wrappers, and next actions
- document status output and add behavior coverage for text, JSON, and read-only obsolete-hook handling

Fixes #144

## Test plan
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `git smee status` subcommand to report hook coverage, detect drift, and identify obsolete hooks
  * Includes `--json` flag for stable JSON output compatible with tooling and automation

* **Documentation**
  * Updated CLI documentation with usage guidance for `status` and `doctor` subcommands, including example output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->