### PR TITLE
Make managed file writes atomic

### DIFF
--- a/crates/git-smee-core/Cargo.toml
+++ b/crates/git-smee-core/Cargo.toml
@@ -9,8 +9,8 @@ toml = { version = "0.9" }
 serde = { version = "1", features = ["derive"] }
 thiserror = { version = "2" }
 rayon = { version = "1" }
+tempfile = "3"
 
 [dev-dependencies]
-tempfile = "3"
 assert2 = { workspace = true }
 proptest = "1"

--- a/crates/git-smee-core/src/installer.rs
+++ b/crates/git-smee-core/src/installer.rs
@@ -1,7 +1,7 @@
 use crate::{DEFAULT_CONFIG_FILE_NAME, SmeeConfig, config::LifeCyclePhase, platform::Platform};
 use std::{
     fs,
-    io::Read,
+    io::{Read, Write},
     path::{Path, PathBuf},
 };
 use thiserror::Error;
@@ -374,7 +374,7 @@ impl HookInstaller for FileSystemHookInstaller {
     fn install_hook(&self, hook_name: &str, hook_content: &str) -> Result<PathBuf, Error> {
         let hook_file = self.hooks_dir.join(hook_name);
         self.ensure_can_write_hook(&hook_file)?;
-        fs::write(&hook_file, hook_content).map_err(|source| Error::FailedToWriteHook {
+        atomic_write_file(&hook_file, hook_content).map_err(|source| Error::FailedToWriteHook {
             path: hook_file.to_string_lossy().to_string(),
             source,
         })?;
@@ -384,7 +384,7 @@ impl HookInstaller for FileSystemHookInstaller {
     fn install_config_file(&self, config_content: &str) -> Result<PathBuf, Error> {
         let config_path = self.repository_root.join(DEFAULT_CONFIG_FILE_NAME);
         self.ensure_can_write_config(&config_path)?;
-        fs::write(&config_path, config_content).map_err(|source| {
+        atomic_write_file(&config_path, config_content).map_err(|source| {
             Error::FailedToWriteConfigFile {
                 path: config_path.to_string_lossy().to_string(),
                 source,
@@ -417,10 +417,40 @@ pub fn write_config_file(
             source,
         })?;
     }
-    fs::write(config_path, config_content).map_err(|source| Error::FailedToWriteConfigFile {
-        path: config_path.to_string_lossy().to_string(),
-        source,
+    atomic_write_file(config_path, config_content).map_err(|source| {
+        Error::FailedToWriteConfigFile {
+            path: config_path.to_string_lossy().to_string(),
+            source,
+        }
     })
+}
+
+fn atomic_write_file(path: &Path, content: &str) -> std::io::Result<()> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let mut temp_file = tempfile::Builder::new()
+        .prefix(".git-smee-")
+        .suffix(".tmp")
+        .tempfile_in(parent)?;
+
+    temp_file.write_all(content.as_bytes())?;
+    temp_file.flush()?;
+    temp_file.as_file().sync_all()?;
+    temp_file.persist(path).map_err(|error| error.error)?;
+    sync_parent_dir(parent)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn sync_parent_dir(parent: &Path) -> std::io::Result<()> {
+    fs::File::open(parent)?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_parent_dir(_parent: &Path) -> std::io::Result<()> {
+    Ok(())
 }
 
 fn ensure_can_write_config_file(config_file: &Path, force_overwrite: bool) -> Result<(), Error> {

--- a/crates/git-smee-core/tests/installer_integration.rs
+++ b/crates/git-smee-core/tests/installer_integration.rs
@@ -82,6 +82,60 @@ fn given_stale_embedded_binary_when_running_installed_hook_then_path_fallback_is
     assert!(stderr.contains(&missing_git_smee.to_string_lossy().to_string()));
 }
 
+#[cfg(unix)]
+#[test]
+fn given_managed_hook_when_reinstalling_then_hook_file_is_atomically_replaced() {
+    use std::os::unix::fs::MetadataExt;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repo = temp_dir.path().join("repo");
+    init_repo(&repo);
+    write_config_fixture(&repo);
+    let config = read_config_from_repo(&repo);
+    let installer = FileSystemHookInstaller::from_path(repo.clone()).unwrap();
+
+    let initial_options = HookScriptOptions::new(
+        PathBuf::from("/tmp/git-smee-initial"),
+        repo.join(DEFAULT_CONFIG_FILE_NAME),
+    );
+    installer::install_hooks_with_options(&config, &installer, &initial_options).unwrap();
+    let pre_commit = resolve_hooks_path_with_git(&repo).join("pre-commit");
+    let initial_inode = fs::metadata(&pre_commit).unwrap().ino();
+
+    let replacement_options = HookScriptOptions::new(
+        PathBuf::from("/tmp/git-smee-replacement"),
+        repo.join(DEFAULT_CONFIG_FILE_NAME),
+    );
+    installer::install_hooks_with_options(&config, &installer, &replacement_options).unwrap();
+
+    let replacement_metadata = fs::metadata(&pre_commit).unwrap();
+    assert_ne!(replacement_metadata.ino(), initial_inode);
+    assert!(
+        fs::read_to_string(pre_commit)
+            .unwrap()
+            .contains("/tmp/git-smee-replacement")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn given_managed_config_when_force_writing_then_config_file_is_atomically_replaced() {
+    use std::os::unix::fs::MetadataExt;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let config_path = temp_dir.path().join(DEFAULT_CONFIG_FILE_NAME);
+    let initial_config = installer::with_managed_header("[hooks]\n");
+    installer::write_config_file(&config_path, &initial_config, true).unwrap();
+    let initial_inode = fs::metadata(&config_path).unwrap().ino();
+
+    let replacement_config = installer::with_managed_header("[hooks.pre-commit]\n");
+    installer::write_config_file(&config_path, &replacement_config, true).unwrap();
+
+    let replacement_metadata = fs::metadata(&config_path).unwrap();
+    assert_ne!(replacement_metadata.ino(), initial_inode);
+    assert_eq!(fs::read_to_string(config_path).unwrap(), replacement_config);
+}
+
 #[test]
 fn given_custom_hooks_path_when_installing_hooks_then_hooks_are_written_to_custom_path() {
     let temp_dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Fixes #137

## Summary
- replace direct managed hook/config writes with same-directory temp-file writes that fsync before atomic persist/rename
- sync the parent directory on Unix after the persisted rename
- move `tempfile` into core runtime dependencies for the atomic-write helper
- add Unix regression coverage that managed hook/config overwrites replace the file inode instead of truncating in place

## Validation
- `cargo test -p git-smee-core atomically_replaced -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability of hook and config file writing with atomic operations to reduce corruption risks during system crashes or interruptions.

* **Tests**
  * Added integration tests to validate atomic file replacement behavior during reinstallation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->