### PR TITLE
Preserve non-UTF-8 Unix hook paths

### DIFF
--- a/crates/git-smee-core/src/installer.rs
+++ b/crates/git-smee-core/src/installer.rs
@@ -617,6 +617,29 @@ pub fn install_hooks_with_options<T: HookInstaller>(
 }
 
 fn shell_single_quote(path: &Path) -> String {
+    unix_shell_path_word(path)
+}
+
+#[cfg(unix)]
+fn unix_shell_path_word(path: &Path) -> String {
+    use std::os::unix::ffi::OsStrExt;
+
+    match path.as_os_str().to_str() {
+        Some(path) => format!("'{}'", path.replace('\'', "'\"'\"'")),
+        None => {
+            let escaped = path
+                .as_os_str()
+                .as_bytes()
+                .iter()
+                .map(|byte| format!(r"\{byte:03o}"))
+                .collect::<String>();
+            format!(r#"$(printf '%b' '{escaped}')"#)
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn unix_shell_path_word(path: &Path) -> String {
     format!("'{}'", path.to_string_lossy().replace('\'', "'\"'\"'"))
 }
 
@@ -890,6 +913,24 @@ mod tests {
             shell_single_quote(path),
             "'/tmp/it'\"'\"'s 100% ready/git-smee'"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shell_single_quote_preserves_non_utf8_unix_bytes_with_printf_escape() {
+        use std::{ffi::OsString, os::unix::ffi::OsStringExt};
+
+        let path = PathBuf::from(OsString::from_vec(
+            b"/tmp/git-smee-\xFF/config.toml".to_vec(),
+        ));
+
+        let escaped = shell_single_quote(&path);
+
+        assert_eq!(
+            escaped,
+            r"$(printf '%b' '\057\164\155\160\057\147\151\164\055\163\155\145\145\055\377\057\143\157\156\146\151\147\056\164\157\155\154')"
+        );
+        assert!(!escaped.contains('\u{FFFD}'));
     }
 
     #[test]

--- a/crates/git-smee-core/tests/installer_integration.rs
+++ b/crates/git-smee-core/tests/installer_integration.rs
@@ -82,7 +82,7 @@ fn given_stale_embedded_binary_when_running_installed_hook_then_path_fallback_is
     assert!(stderr.contains(&missing_git_smee.to_string_lossy().to_string()));
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 #[test]
 fn given_non_utf8_unix_paths_when_running_installed_hook_then_original_bytes_are_forwarded() {
     use std::{

--- a/crates/git-smee-core/tests/installer_integration.rs
+++ b/crates/git-smee-core/tests/installer_integration.rs
@@ -84,6 +84,59 @@ fn given_stale_embedded_binary_when_running_installed_hook_then_path_fallback_is
 
 #[cfg(unix)]
 #[test]
+fn given_non_utf8_unix_paths_when_running_installed_hook_then_original_bytes_are_forwarded() {
+    use std::{
+        ffi::OsString,
+        os::{unix::ffi::OsStrExt, unix::ffi::OsStringExt, unix::fs::PermissionsExt},
+    };
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repo = temp_dir.path().join("repo");
+    init_repo(&repo);
+    write_config_fixture(&repo);
+
+    let non_utf8_dir = temp_dir
+        .path()
+        .join(OsString::from_vec(b"non-utf8-\xFF".to_vec()));
+    fs::create_dir(&non_utf8_dir).unwrap();
+    let observed_config_arg = temp_dir.path().join("observed-config-arg");
+    let fake_git_smee = non_utf8_dir.join("git-smee");
+    fs::write(
+        &fake_git_smee,
+        format!(
+            "#!/usr/bin/env sh\nprintf '%s' \"$2\" > '{}'\n",
+            observed_config_arg.display()
+        ),
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&fake_git_smee).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_git_smee, permissions).unwrap();
+
+    let config_path = non_utf8_dir.join(DEFAULT_CONFIG_FILE_NAME);
+    let config = read_config_from_repo(&repo);
+    let installer = FileSystemHookInstaller::from_path(repo.clone()).unwrap();
+    let options = HookScriptOptions::new(fake_git_smee, config_path.clone());
+    installer::install_hooks_with_options(&config, &installer, &options).unwrap();
+
+    let output = Command::new(resolve_hooks_path_with_git(&repo).join("pre-commit"))
+        .current_dir(&repo)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "hook failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read(observed_config_arg).unwrap(),
+        config_path.as_os_str().as_bytes()
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn given_managed_hook_when_reinstalling_then_hook_file_is_atomically_replaced() {
     use std::os::unix::fs::MetadataExt;
 


### PR DESCRIPTION
Fixes #82

## Summary
- Preserve Unix non-UTF-8 path bytes when rendering installed hook wrappers instead of using lossy UTF-8 replacement characters.
- Use a POSIX `printf '%b'` command-substitution path word for non-UTF-8 Unix paths while keeping the existing readable single-quote rendering for normal UTF-8 paths.
- Add a Unix integration regression proving an installed wrapper executes a fake `git-smee` from a non-UTF-8 path and forwards the original config-path bytes.

## Validation
- RED: `cargo test -p git-smee-core given_non_utf8_unix_paths_when_running_installed_hook_then_original_bytes_are_forwarded -- --nocapture` failed with the previous lossy renderer because the wrapper looked for `non-utf8-�/git-smee`.
- GREEN: `cargo test -p git-smee-core given_non_utf8_unix_paths_when_running_installed_hook_then_original_bytes_are_forwarded -- --nocapture`
- GREEN: `cargo test -p git-smee-core shell_single_quote_preserves_non_utf8_unix_bytes_with_printf_escape -- --nocapture`
- GREEN: `cargo fmt --all -- --check`
- GREEN: `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- GREEN: `cargo test --workspace --all-targets --all-features`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced handling of non-UTF-8 filesystem paths in hook installation and execution. Git-smee now correctly preserves original path bytes when operating with non-standard character encodings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->