### PR TITLE
feat(cli): add init templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,23 @@ cargo install --path crates/git-smee-cli
    This creates a `.git-smee.toml` file with a default pre-commit hook.
    If the file already exists, `init` refuses to overwrite it unless you pass `--force`.
 
+   You can start from an explicit built-in template and then edit the generated TOML:
+
+   ```bash
+   git smee init --template rust
+   git smee init --template node-pnpm
+   git smee init --template generic
+   ```
+
+   Available templates are:
+
+   - `minimal` (default): a single starter pre-commit command.
+   - `rust`: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `cargo test --workspace --all-targets --all-features`.
+   - `node-pnpm`: `pnpm lint` and `pnpm test` hooks.
+   - `generic`: an editable shell-command starter with commented examples.
+
+   Unknown template names are rejected with an error that lists valid template names.
+
 2. Edit `.git-smee.toml` to define your hooks:
 
    ```toml

--- a/crates/git-smee-cli/src/main.rs
+++ b/crates/git-smee-cli/src/main.rs
@@ -7,7 +7,7 @@ use std::{
     str::FromStr,
 };
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use git_smee_core::{
     DEFAULT_CONFIG_FILE_NAME, SmeeConfig,
     config::{self, LifeCyclePhase},
@@ -55,6 +55,13 @@ enum Command {
     Initialize {
         #[arg(long, help = "Overwrite an existing .git-smee.toml file")]
         force: bool,
+        #[arg(
+            long,
+            default_value_t = InitTemplate::Minimal,
+            value_enum,
+            help = "Starter template to write"
+        )]
+        template: InitTemplate,
     },
     #[command(name = "doctor", about = "Diagnose git-smee repository setup")]
     Doctor {
@@ -67,6 +74,66 @@ enum Command {
         json: bool,
     },
 }
+
+#[derive(Clone, Debug, ValueEnum)]
+enum InitTemplate {
+    Minimal,
+    Rust,
+    NodePnpm,
+    Generic,
+}
+
+impl std::fmt::Display for InitTemplate {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            Self::Minimal => "minimal",
+            Self::Rust => "rust",
+            Self::NodePnpm => "node-pnpm",
+            Self::Generic => "generic",
+        };
+        formatter.write_str(name)
+    }
+}
+
+impl InitTemplate {
+    fn config_content(&self) -> Result<String, config::Error> {
+        match self {
+            Self::Minimal => (&config::SmeeConfig::default()).try_into(),
+            Self::Rust => Ok(RUST_INIT_TEMPLATE.to_string()),
+            Self::NodePnpm => Ok(NODE_PNPM_INIT_TEMPLATE.to_string()),
+            Self::Generic => Ok(GENERIC_INIT_TEMPLATE.to_string()),
+        }
+    }
+}
+
+const RUST_INIT_TEMPLATE: &str = r#"# Rust starter: edit commands to match your workspace policy.
+[[pre-commit]]
+command = "cargo fmt --all -- --check"
+
+[[pre-commit]]
+command = "cargo clippy --workspace --all-targets --all-features -- -D warnings"
+
+[[pre-push]]
+command = "cargo test --workspace --all-targets --all-features"
+"#;
+
+const NODE_PNPM_INIT_TEMPLATE: &str = r#"# Node/pnpm starter: commands are explicit and editable.
+[[pre-commit]]
+command = "pnpm lint"
+
+[[pre-push]]
+command = "pnpm test"
+"#;
+
+const GENERIC_INIT_TEMPLATE: &str = r#"# Generic starter: replace these commands with your project's checks.
+# Add another [[pre-commit]] or [[pre-push]] table for each command to run.
+[[pre-commit]]
+command = "echo 'replace me with your pre-commit check'"
+
+# Example:
+# [[pre-push]]
+# command = "./scripts/test"
+"#;
 
 fn main() {
     if let Err(error) = run() {
@@ -113,20 +180,20 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             }
             Ok(())
         }
-        Command::Initialize { force } => {
+        Command::Initialize { force, template } => {
             repository::ensure_in_repo_root()?;
             let installer = installer::FileSystemHookInstaller::from_default_with_force(force)?;
             println!(
                 "Initializing {} configuration file...",
                 config_path.display()
             );
-            let default_config: String = (&config::SmeeConfig::default()).try_into()?;
-            let default_config = installer::with_managed_header(&default_config);
+            let template_config = template.config_content()?;
+            let template_config = installer::with_managed_header(&template_config);
 
             if is_default_config_path(&config_path, &env::current_dir()?) {
-                installer.install_config_file(&default_config)?;
+                installer.install_config_file(&template_config)?;
             } else {
-                installer::write_config_file(&config_path, &default_config, force)?;
+                installer::write_config_file(&config_path, &template_config, force)?;
             }
             Ok(())
         }

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -567,6 +567,75 @@ fn given_existing_config_when_init_with_force_then_it_overwrites_config() {
 }
 
 #[test]
+fn given_rust_template_when_init_then_config_parses_and_installs() {
+    let test_repo = common::TestRepo::default();
+    fs::remove_file(test_repo.config_path()).expect("failed to remove default config");
+
+    Command::new(cargo::cargo_bin!("git-smee"))
+        .current_dir(&test_repo.path)
+        .args(["init", "--template", "rust"])
+        .assert()
+        .success();
+
+    let initialized = fs::read_to_string(test_repo.config_path()).unwrap();
+    assert!(initialized.contains(MANAGED_FILE_MARKER));
+    assert!(initialized.contains("cargo fmt --all -- --check"));
+    assert!(
+        initialized
+            .contains("cargo clippy --workspace --all-targets --all-features -- -D warnings")
+    );
+
+    Command::new(cargo::cargo_bin!("git-smee"))
+        .current_dir(&test_repo.path)
+        .arg("install")
+        .assert()
+        .success();
+    test_repo.assert_hooks_installed(vec![LifeCyclePhase::PreCommit, LifeCyclePhase::PrePush]);
+}
+
+#[test]
+fn given_node_pnpm_template_when_init_then_config_parses_and_installs() {
+    let test_repo = common::TestRepo::default();
+    fs::remove_file(test_repo.config_path()).expect("failed to remove default config");
+
+    Command::new(cargo::cargo_bin!("git-smee"))
+        .current_dir(&test_repo.path)
+        .args(["init", "--template", "node-pnpm"])
+        .assert()
+        .success();
+
+    let initialized = fs::read_to_string(test_repo.config_path()).unwrap();
+    assert!(initialized.contains("pnpm lint"));
+    assert!(initialized.contains("pnpm test"));
+
+    Command::new(cargo::cargo_bin!("git-smee"))
+        .current_dir(&test_repo.path)
+        .arg("install")
+        .assert()
+        .success();
+    test_repo.assert_hooks_installed(vec![LifeCyclePhase::PreCommit, LifeCyclePhase::PrePush]);
+}
+
+#[test]
+fn given_unknown_template_when_init_then_error_lists_valid_templates() {
+    let test_repo = common::TestRepo::default();
+    fs::remove_file(test_repo.config_path()).expect("failed to remove default config");
+
+    Command::new(cargo::cargo_bin!("git-smee"))
+        .current_dir(&test_repo.path)
+        .args(["init", "--template", "python"])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("invalid value 'python'")
+                .and(predicate::str::contains("minimal"))
+                .and(predicate::str::contains("rust"))
+                .and(predicate::str::contains("node-pnpm"))
+                .and(predicate::str::contains("generic")),
+        );
+}
+
+#[test]
 fn given_unmanaged_hook_when_install_without_force_then_it_fails_and_preserves_hook() {
     let test_repo = common::TestRepo::default();
     let pre_commit = test_repo.path.join(".git").join("hooks").join("pre-commit");

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -617,6 +617,29 @@ fn given_node_pnpm_template_when_init_then_config_parses_and_installs() {
 }
 
 #[test]
+fn given_generic_template_when_init_then_config_parses_and_installs() {
+    let test_repo = common::TestRepo::default();
+    fs::remove_file(test_repo.config_path()).expect("failed to remove default config");
+
+    Command::new(cargo::cargo_bin!("git-smee"))
+        .current_dir(&test_repo.path)
+        .args(["init", "--template", "generic"])
+        .assert()
+        .success();
+
+    let initialized = fs::read_to_string(test_repo.config_path()).unwrap();
+    assert!(initialized.contains("replace me with your pre-commit check"));
+    assert!(initialized.contains("./scripts/test"));
+
+    Command::new(cargo::cargo_bin!("git-smee"))
+        .current_dir(&test_repo.path)
+        .arg("install")
+        .assert()
+        .success();
+    test_repo.assert_hooks_installed(vec![LifeCyclePhase::PreCommit]);
+}
+
+#[test]
 fn given_unknown_template_when_init_then_error_lists_valid_templates() {
     let test_repo = common::TestRepo::default();
     fs::remove_file(test_repo.config_path()).expect("failed to remove default config");


### PR DESCRIPTION
## Summary
- add `git smee init --template <name>` with built-in `minimal`, `rust`, `node-pnpm`, and `generic` templates
- generate explicit editable TOML starter configs while preserving existing `--force` behavior
- document available templates and unknown-template handling in the README

Fixes #146

## Test plan
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--template` option to the `init` command. Select from four starter templates (`minimal`, `rust`, `node-pnpm`, `generic`) to initialize projects with pre-configured settings.

* **Documentation**
  * Updated Quick Start guide with template initialization instructions.

* **Tests**
  * Added integration tests for template selection and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->