### PR TITLE
feat(cli): add hook migration suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,9 +282,10 @@ Use `git smee status --json` when tooling needs stable fields such as `status`,
 
 Run `git smee migrate-hooks` before replacing an existing `.git/hooks/*` setup.
 It is read-only: unmanaged Git hook files are reported as parseable TOML snippets
-that call the preserved legacy hook path (for example `.git/hooks/pre-commit`),
-while git-smee-managed wrappers are ignored and listed in a comment. Review the
-suggestions before copying them into `.git-smee.toml`.
+that call a preserved legacy copy outside the managed hooks directory (for
+example `.git-smee/legacy/pre-commit`), while git-smee-managed wrappers are
+ignored and listed in a comment. Move each legacy script as instructed before
+copying the suggestions into `.git-smee.toml` and running `git smee install`.
 
 Run `git smee doctor` when onboarding a repository, after changing `core.hooksPath`, or when a
 hook does not fire as expected. The human-readable report groups `ok`, `warnings`, and `errors`

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ git smee install [--force] [--config <path>]    # Install hooks from the selecte
 git smee [--config <path>] run <hook> [hook-args...]           # Run a specific git hook
 git smee [--config <path>] status [--json]      # Show hook coverage and drift
 git smee [--config <path>] doctor [--json]      # Diagnose repository setup and hook drift
+git smee migrate-hooks                          # Suggest config entries for existing hooks
 ```
 
 Run `git smee status` as a read-only onboarding or CI smoke check after editing
@@ -278,6 +279,12 @@ next actions:
 Use `git smee status --json` when tooling needs stable fields such as `status`,
 `hooks[].configured_command_count`, `hooks[].state`, `obsolete_managed_hooks`, and
 `next_actions`.
+
+Run `git smee migrate-hooks` before replacing an existing `.git/hooks/*` setup.
+It is read-only: unmanaged Git hook files are reported as parseable TOML snippets
+that call the preserved legacy hook path (for example `.git/hooks/pre-commit`),
+while git-smee-managed wrappers are ignored and listed in a comment. Review the
+suggestions before copying them into `.git-smee.toml`.
 
 Run `git smee doctor` when onboarding a repository, after changing `core.hooksPath`, or when a
 hook does not fire as expected. The human-readable report groups `ok`, `warnings`, and `errors`

--- a/crates/git-smee-cli/src/main.rs
+++ b/crates/git-smee-cli/src/main.rs
@@ -74,6 +74,11 @@ enum Command {
         #[arg(long, help = "Emit a stable JSON status report")]
         json: bool,
     },
+    #[command(
+        name = "migrate-hooks",
+        about = "Suggest git-smee config entries for existing unmanaged Git hooks"
+    )]
+    MigrateHooks,
 }
 
 #[derive(Clone, Debug, ValueEnum)]
@@ -200,7 +205,98 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         }
         Command::Doctor { json } => doctor::run_doctor(&config_path, json),
         Command::Status { json } => status::run_status(&config_path, json),
+        Command::MigrateHooks => run_migrate_hooks(),
     }
+}
+
+fn run_migrate_hooks() -> Result<(), Box<dyn std::error::Error>> {
+    repository::ensure_in_repo_root()?;
+    let installer = installer::FileSystemHookInstaller::from_default()?;
+    let report = MigrationReport::from_hooks_dir(installer.effective_hooks_dir())?;
+
+    println!("{}", report.to_toml_suggestions());
+    Ok(())
+}
+
+#[derive(Debug, Default)]
+struct MigrationReport {
+    unmanaged_hooks: Vec<LifeCyclePhase>,
+    managed_hooks: Vec<LifeCyclePhase>,
+}
+
+impl MigrationReport {
+    fn from_hooks_dir(hooks_dir: &Path) -> Result<Self, installer::Error> {
+        let mut report = Self::default();
+
+        for phase in LifeCyclePhase::all() {
+            let hook_path = hooks_dir.join(phase.as_str());
+            if !hook_path.is_file() {
+                continue;
+            }
+
+            if installer::has_managed_header(&hook_path)? {
+                report.managed_hooks.push(*phase);
+            } else {
+                report.unmanaged_hooks.push(*phase);
+            }
+        }
+
+        Ok(report)
+    }
+
+    fn to_toml_suggestions(&self) -> String {
+        let mut lines = vec![
+            "# git-smee hook migration suggestions".to_string(),
+            "# Review these commands before adding them to .git-smee.toml.".to_string(),
+            "# Dry-run only: this command does not modify hook files or configuration.".to_string(),
+        ];
+
+        if !self.managed_hooks.is_empty() {
+            lines.push(format!(
+                "# Ignored managed git-smee hooks: {}",
+                join_phase_names(&self.managed_hooks)
+            ));
+        }
+
+        if self.unmanaged_hooks.is_empty() {
+            lines.push("# No unmanaged Git hooks found.".to_string());
+            return finish_lines(lines);
+        }
+
+        lines.push(String::new());
+        for phase in &self.unmanaged_hooks {
+            lines.push(format!("[[{}]]", phase.as_str()));
+            lines.push(format!(
+                "command = \"{}\"",
+                toml_escape_basic_string(&format!(".git/hooks/{}", phase.as_str()))
+            ));
+            lines.push(
+                "# TODO: preserve or refactor the legacy hook script before deleting it."
+                    .to_string(),
+            );
+            lines.push(String::new());
+        }
+
+        finish_lines(lines)
+    }
+}
+
+fn join_phase_names(phases: &[LifeCyclePhase]) -> String {
+    phases
+        .iter()
+        .map(|phase| phase.as_str())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn toml_escape_basic_string(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn finish_lines(lines: Vec<String>) -> String {
+    let mut output = lines.join("\n");
+    output.push('\n');
+    output
 }
 
 fn resolve_config_path(cli_config: Option<PathBuf>, invocation_dir: &Path) -> PathBuf {

--- a/crates/git-smee-cli/src/main.rs
+++ b/crates/git-smee-cli/src/main.rs
@@ -268,12 +268,12 @@ impl MigrationReport {
             lines.push(format!("[[{}]]", phase.as_str()));
             lines.push(format!(
                 "command = \"{}\"",
-                toml_escape_basic_string(&format!(".git/hooks/{}", phase.as_str()))
+                toml_escape_basic_string(&format!(".git-smee/legacy/{}", phase.as_str()))
             ));
-            lines.push(
-                "# TODO: preserve or refactor the legacy hook script before deleting it."
-                    .to_string(),
-            );
+            lines.push(format!(
+                "# TODO: move .git/hooks/{0} to .git-smee/legacy/{0} before running git smee install.",
+                phase.as_str()
+            ));
             lines.push(String::new());
         }
 

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -71,6 +71,7 @@ fn given_unmanaged_hooks_when_migrate_hooks_then_prints_parseable_toml_suggestio
         .success()
         .stdout(predicate::str::contains("[[pre-commit]]"))
         .stdout(predicate::str::contains("[[commit-msg]]"))
+        .stdout(predicate::str::contains(".git-smee/legacy/pre-commit"))
         .stdout(predicate::str::contains("pre-commit.sample").not())
         .get_output()
         .stdout

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -31,6 +31,87 @@ fn given_git_smee_when_help_then_success() {
 }
 
 #[test]
+fn given_no_unmanaged_hooks_when_migrate_hooks_then_reports_no_suggestions() {
+    let test_repo = common::TestRepo::default();
+
+    Command::new(cargo::cargo_bin!("git-smee"))
+        .current_dir(&test_repo.path)
+        .arg("migrate-hooks")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("# No unmanaged Git hooks found")
+                .and(predicate::str::contains("[[").not()),
+        );
+}
+
+#[test]
+fn given_unmanaged_hooks_when_migrate_hooks_then_prints_parseable_toml_suggestions() {
+    let test_repo = common::TestRepo::default();
+    fs::write(
+        test_repo.path.join(".git/hooks/pre-commit"),
+        "#!/usr/bin/env sh\necho legacy pre-commit\n",
+    )
+    .unwrap();
+    fs::write(
+        test_repo.path.join(".git/hooks/commit-msg"),
+        "#!/usr/bin/env sh\necho legacy commit-msg\n",
+    )
+    .unwrap();
+    fs::write(
+        test_repo.path.join(".git/hooks/pre-commit.sample"),
+        "sample",
+    )
+    .unwrap();
+
+    let output = Command::new(cargo::cargo_bin!("git-smee"))
+        .current_dir(&test_repo.path)
+        .arg("migrate-hooks")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("[[pre-commit]]"))
+        .stdout(predicate::str::contains("[[commit-msg]]"))
+        .stdout(predicate::str::contains("pre-commit.sample").not())
+        .get_output()
+        .stdout
+        .clone();
+
+    let suggested_config = test_repo.path.join("suggested.git-smee.toml");
+    fs::write(&suggested_config, output).unwrap();
+    let parsed = git_smee_core::SmeeConfig::from_toml(&suggested_config).unwrap();
+    assert!(parsed.hooks.contains_key(&LifeCyclePhase::PreCommit));
+    assert!(parsed.hooks.contains_key(&LifeCyclePhase::CommitMsg));
+}
+
+#[test]
+fn given_managed_and_unmanaged_hooks_when_migrate_hooks_then_ignores_managed_wrappers() {
+    let test_repo = common::TestRepo::default();
+    fs::write(
+        test_repo.path.join(".git/hooks/pre-push"),
+        format!("#!/usr/bin/env sh\n# {MANAGED_FILE_MARKER}\ngit-smee run pre-push\n"),
+    )
+    .unwrap();
+    fs::write(
+        test_repo.path.join(".git/hooks/post-merge"),
+        "#!/usr/bin/env sh\necho legacy post-merge\n",
+    )
+    .unwrap();
+
+    Command::new(cargo::cargo_bin!("git-smee"))
+        .current_dir(&test_repo.path)
+        .arg("migrate-hooks")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("[[post-merge]]")
+                .and(predicate::str::contains("[[pre-push]]").not())
+                .and(predicate::str::contains(
+                    "# Ignored managed git-smee hooks: pre-push",
+                )),
+        );
+}
+
+#[test]
 fn given_non_repo_dir_when_help_then_success() {
     let non_repo_dir = TempDir::new().unwrap();
 


### PR DESCRIPTION
## Summary
- Add `git smee migrate-hooks` as a read-only migration helper for existing unmanaged Git hooks.
- Scan Git's effective hooks directory, ignore git-smee-managed wrappers, and emit parseable TOML suggestions that preserve legacy hook scripts by path.
- Document the migration helper and add CLI integration coverage for no hooks, unmanaged hooks, managed wrappers, and mixed cases.

Fixes #147

## Test plan
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `git smee migrate-hooks` command that scans for unmanaged Git hooks and generates TOML-formatted suggestions for migration review.

* **Documentation**
  * Updated CLI command reference with documentation for the new migrate-hooks command.

* **Tests**
  * Added integration tests for the migrate-hooks command covering scenarios with no unmanaged hooks, multiple unmanaged hooks, and mixed managed/unmanaged setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->