### PR TITLE
feat(core): support Windows positional hook args

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,12 +224,17 @@ When Git invokes a hook with positional arguments (for example `commit-msg <path
 `post-checkout <old> <new> <flag>`), installed git-smee wrappers forward those arguments to
 `git smee run`.
 
-On Unix, forwarded hook arguments are available as shell positional parameters inside configured
-commands (`$1`, `$2`, ...). Example:
+Forwarded hook arguments are available as shell positional parameters inside configured
+commands: `$1`, `$2`, ... on Unix and `%1`, `%2`, ... on Windows. Examples:
 
 ```toml
 [[commit-msg]]
 command = "test -n \"$1\""
+```
+
+```toml
+[[commit-msg]]
+command = "if \"%1\"==\"COMMIT_EDITMSG\" exit /b 0"
 ```
 
 On all platforms, git-smee also exports forwarded hook args as environment variables:

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -1333,6 +1333,24 @@ command = "test \"$1\" = \"COMMIT_EDITMSG\""
         .success();
 }
 
+#[cfg(windows)]
+#[test]
+fn given_hook_args_when_running_on_windows_then_command_receives_positional_args() {
+    let test_repo = common::TestRepo::default();
+    test_repo.write_config(
+        r#"
+[[commit-msg]]
+command = "if \"%1\"==\"COMMIT_EDITMSG\" (if \"%2\"==\"metadata\" (exit /b 0) else (exit /b 1)) else (exit /b 1)"
+"#,
+    );
+
+    let mut cmd = Command::new(cargo::cargo_bin!("git-smee"));
+    cmd.current_dir(&test_repo.path)
+        .args(["run", "commit-msg", "COMMIT_EDITMSG", "metadata"])
+        .assert()
+        .success();
+}
+
 #[test]
 fn given_relative_config_env_from_subdir_when_running_then_cli_resolves_from_invocation_dir() {
     let test_repo = common::TestRepo::default();

--- a/crates/git-smee-core/src/executor.rs
+++ b/crates/git-smee-core/src/executor.rs
@@ -353,14 +353,20 @@ impl CommandRunner for PlatformCommandRunner<'_> {
         stdin_payload: Option<&[u8]>,
     ) -> Result<Option<i32>, std::io::Error> {
         let mut shell_command = self.platform.create_command();
-        shell_command.arg(command);
         apply_hook_arg_env(&mut shell_command, hook_args);
+        let mut _windows_command_script = None;
         match self.platform {
             Platform::Unix => {
+                shell_command.arg(command);
                 shell_command.arg("--");
                 shell_command.args(hook_args);
             }
-            Platform::Windows => {}
+            Platform::Windows => {
+                let command_script = create_windows_command_script(command)?;
+                shell_command.arg(&command_script);
+                shell_command.args(hook_args);
+                _windows_command_script = Some(command_script);
+            }
         }
         if stdin_payload.is_some() {
             shell_command.stdin(Stdio::piped());
@@ -400,6 +406,20 @@ impl CommandRunner for PlatformCommandRunner<'_> {
     fn shell_display(&self) -> &'static str {
         self.platform.shell_display()
     }
+}
+
+fn create_windows_command_script(command: &str) -> Result<tempfile::TempPath, io::Error> {
+    let mut script = tempfile::Builder::new()
+        .prefix("git-smee-command-")
+        .suffix(".cmd")
+        .tempfile()?;
+    script.write_all(windows_command_script(command).as_bytes())?;
+    script.flush()?;
+    Ok(script.into_temp_path())
+}
+
+fn windows_command_script(command: &str) -> String {
+    format!("@echo off\r\n{command}\r\n")
 }
 
 fn apply_hook_arg_env(shell_command: &mut std::process::Command, hook_args: &[String]) {
@@ -841,6 +861,13 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(runner.calls(), vec!["check-commit-message"]);
         assert_eq!(runner.hook_args_calls(), vec![hook_args]);
+    }
+
+    #[test]
+    fn given_windows_command_script_when_building_then_command_can_read_batch_parameters() {
+        let script = windows_command_script("if \"%1\"==\"alpha\" exit /b 0");
+
+        assert_eq!(script, "@echo off\r\nif \"%1\"==\"alpha\" exit /b 0\r\n");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Run Windows configured hook commands from a temporary `.cmd` script so `%1`, `%2`, etc. receive forwarded hook arguments.
- Keep the existing environment-variable hook arg contract unchanged.
- Add Windows-specific CLI regression coverage and update README hook-argument docs.

Fixes #138

## Test plan
- `cargo test -p git-smee-core given_windows_command_script_when_building_then_command_can_read_batch_parameters`
- `cargo test -p git-smee-cli given_hook_args_when_running_then_command_receives_positional_args`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`
