### PR TITLE
refactor(cli): extract command handler boundaries

### DIFF
--- a/crates/git-smee-cli/src/commands/init.rs
+++ b/crates/git-smee-cli/src/commands/init.rs
@@ -1,0 +1,114 @@
+use std::{env, path::Path};
+
+use clap::ValueEnum;
+use git_smee_core::{config, installer, installer::HookInstaller, repository};
+
+use crate::config_path::is_default_config_path;
+
+#[derive(Clone, Debug, ValueEnum)]
+pub(crate) enum InitTemplate {
+    Minimal,
+    Rust,
+    NodePnpm,
+    Generic,
+}
+
+impl std::fmt::Display for InitTemplate {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            Self::Minimal => "minimal",
+            Self::Rust => "rust",
+            Self::NodePnpm => "node-pnpm",
+            Self::Generic => "generic",
+        };
+        formatter.write_str(name)
+    }
+}
+
+impl InitTemplate {
+    fn config_content(&self) -> Result<String, config::Error> {
+        match self {
+            Self::Minimal => (&config::SmeeConfig::default()).try_into(),
+            Self::Rust => Ok(RUST_INIT_TEMPLATE.to_string()),
+            Self::NodePnpm => Ok(NODE_PNPM_INIT_TEMPLATE.to_string()),
+            Self::Generic => Ok(GENERIC_INIT_TEMPLATE.to_string()),
+        }
+    }
+}
+
+const RUST_INIT_TEMPLATE: &str = r#"# Rust starter: edit commands to match your workspace policy.
+[[pre-commit]]
+command = "cargo fmt --all -- --check"
+
+[[pre-commit]]
+command = "cargo clippy --workspace --all-targets --all-features -- -D warnings"
+
+[[pre-push]]
+command = "cargo test --workspace --all-targets --all-features"
+"#;
+
+const NODE_PNPM_INIT_TEMPLATE: &str = r#"# Node/pnpm starter: commands are explicit and editable.
+[[pre-commit]]
+command = "pnpm lint"
+
+[[pre-push]]
+command = "pnpm test"
+"#;
+
+const GENERIC_INIT_TEMPLATE: &str = r#"# Generic starter: replace these commands with your project's checks.
+# Add another [[pre-commit]] or [[pre-push]] table for each command to run.
+[[pre-commit]]
+command = "echo 'replace me with your pre-commit check'"
+
+# Example:
+# [[pre-push]]
+# command = "./scripts/test"
+"#;
+
+pub(crate) fn run_init(
+    config_path: &Path,
+    force: bool,
+    template: &InitTemplate,
+) -> Result<(), Box<dyn std::error::Error>> {
+    repository::ensure_in_repo_root()?;
+    let installer = installer::FileSystemHookInstaller::from_default_with_force(force)?;
+    println!(
+        "Initializing {} configuration file...",
+        config_path.display()
+    );
+    let template_config = template.config_content()?;
+    let template_config = installer::with_managed_header(&template_config);
+
+    if is_default_config_path(config_path, &env::current_dir()?) {
+        installer.install_config_file(&template_config)?;
+    } else {
+        installer::write_config_file(config_path, &template_config, force)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn template_names_match_cli_values() {
+        assert_eq!(InitTemplate::Minimal.to_string(), "minimal");
+        assert_eq!(InitTemplate::Rust.to_string(), "rust");
+        assert_eq!(InitTemplate::NodePnpm.to_string(), "node-pnpm");
+        assert_eq!(InitTemplate::Generic.to_string(), "generic");
+    }
+
+    #[test]
+    fn non_minimal_templates_include_expected_hooks() {
+        let rust = InitTemplate::Rust.config_content().expect("rust template");
+        assert!(rust.contains("[[pre-commit]]"));
+        assert!(rust.contains("[[pre-push]]"));
+
+        let node = InitTemplate::NodePnpm
+            .config_content()
+            .expect("node template");
+        assert!(node.contains("pnpm lint"));
+        assert!(node.contains("pnpm test"));
+    }
+}

--- a/crates/git-smee-cli/src/commands/install.rs
+++ b/crates/git-smee-cli/src/commands/install.rs
@@ -1,0 +1,22 @@
+use std::{env, path::Path};
+
+use git_smee_core::{installer, repository};
+
+use crate::config_path::{normalize_config_path_for_hook_script, read_config_file};
+
+pub(crate) fn run_install(
+    config_path: &Path,
+    force: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    repository::ensure_in_repo_root()?;
+    let installer = installer::FileSystemHookInstaller::from_default_with_force(force)?;
+    let config_path_for_hooks =
+        normalize_config_path_for_hook_script(config_path, &env::current_dir()?)?;
+    let hook_script_options =
+        installer::HookScriptOptions::new(env::current_exe()?, config_path_for_hooks);
+    println!("Installing hooks...");
+    let config = read_config_file(config_path)?;
+    installer::install_hooks_with_options(&config, &installer, &hook_script_options)?;
+    println!("Hooks installed successfully.");
+    Ok(())
+}

--- a/crates/git-smee-cli/src/commands/mod.rs
+++ b/crates/git-smee-cli/src/commands/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod init;
+pub(crate) mod install;
+pub(crate) mod run;

--- a/crates/git-smee-cli/src/commands/run.rs
+++ b/crates/git-smee-cli/src/commands/run.rs
@@ -1,0 +1,107 @@
+use std::{
+    env,
+    io::{self, IsTerminal, Read},
+    path::Path,
+    str::FromStr,
+};
+
+use git_smee_core::{config::LifeCyclePhase, executor, repository};
+
+use crate::config_path::read_config_file;
+
+const DEFAULT_MAX_HOOK_STDIN_BYTES: u64 = 10 * 1024 * 1024;
+const HOOK_STDIN_LIMIT_ENV: &str = "GIT_SMEE_HOOK_STDIN_LIMIT_BYTES";
+const DEFAULT_HOOK_STDIN_LIMIT_DISPLAY: &str = "10 MiB";
+
+pub(crate) fn run_hook(
+    config_path: &Path,
+    hook: &str,
+    hook_args: &[String],
+) -> Result<(), Box<dyn std::error::Error>> {
+    repository::ensure_in_repo_root()?;
+    let phase = LifeCyclePhase::from_str(hook)?;
+    let stdin_payload = read_hook_stdin_for_phase(phase)?;
+    let config = read_config_file(config_path)?;
+    let summary =
+        executor::execute_hook_with_summary(&config, phase, hook_args, stdin_payload.as_deref())?;
+    for line in summary.text_lines(phase) {
+        println!("{line}");
+    }
+    if let Some(error) = summary.error() {
+        return Err(Box::new(error));
+    }
+    Ok(())
+}
+
+fn read_hook_stdin_for_phase(phase: LifeCyclePhase) -> io::Result<Option<Vec<u8>>> {
+    // proc-receive is an interactive pkt-line protocol: Git waits for the hook to
+    // answer before closing stdin, so buffering until EOF would deadlock before
+    // the configured command is spawned. Let the command inherit stdin instead.
+    if phase == LifeCyclePhase::ProcReceive {
+        return Ok(None);
+    }
+    read_hook_stdin()
+}
+
+fn read_hook_stdin() -> io::Result<Option<Vec<u8>>> {
+    let stdin = io::stdin();
+    if stdin.is_terminal() {
+        return Ok(None);
+    }
+
+    let max_hook_stdin_bytes = max_hook_stdin_bytes()?;
+    let mut payload = Vec::new();
+    stdin
+        .lock()
+        .take(max_hook_stdin_bytes + 1)
+        .read_to_end(&mut payload)?;
+    if payload.len() as u64 > max_hook_stdin_bytes {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "hook stdin exceeds the {} limit",
+                hook_stdin_limit_display(max_hook_stdin_bytes)
+            ),
+        ));
+    }
+    Ok(Some(payload))
+}
+
+fn max_hook_stdin_bytes() -> io::Result<u64> {
+    let Some(value) = env::var_os(HOOK_STDIN_LIMIT_ENV) else {
+        return Ok(DEFAULT_MAX_HOOK_STDIN_BYTES);
+    };
+    let value = value.to_string_lossy();
+    value.parse::<u64>().map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("{HOOK_STDIN_LIMIT_ENV} must be an unsigned byte count: {error}"),
+        )
+    })
+}
+
+fn hook_stdin_limit_display(limit: u64) -> String {
+    if limit == DEFAULT_MAX_HOOK_STDIN_BYTES {
+        DEFAULT_HOOK_STDIN_LIMIT_DISPLAY.to_string()
+    } else {
+        format!("{limit} bytes")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_limit_uses_human_readable_display() {
+        assert_eq!(
+            hook_stdin_limit_display(DEFAULT_MAX_HOOK_STDIN_BYTES),
+            "10 MiB"
+        );
+    }
+
+    #[test]
+    fn custom_limit_uses_byte_display() {
+        assert_eq!(hook_stdin_limit_display(42), "42 bytes");
+    }
+}

--- a/crates/git-smee-cli/src/commands/run.rs
+++ b/crates/git-smee-cli/src/commands/run.rs
@@ -53,7 +53,7 @@ fn read_hook_stdin() -> io::Result<Option<Vec<u8>>> {
     let mut payload = Vec::new();
     stdin
         .lock()
-        .take(max_hook_stdin_bytes + 1)
+        .take(stdin_sentinel_read_limit(max_hook_stdin_bytes))
         .read_to_end(&mut payload)?;
     if payload.len() as u64 > max_hook_stdin_bytes {
         return Err(io::Error::new(
@@ -88,6 +88,10 @@ fn hook_stdin_limit_display(limit: u64) -> String {
     }
 }
 
+fn stdin_sentinel_read_limit(max_hook_stdin_bytes: u64) -> u64 {
+    max_hook_stdin_bytes.saturating_add(1)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -103,5 +107,11 @@ mod tests {
     #[test]
     fn custom_limit_uses_byte_display() {
         assert_eq!(hook_stdin_limit_display(42), "42 bytes");
+    }
+
+    #[test]
+    fn sentinel_read_limit_saturates_at_u64_max() {
+        assert_eq!(stdin_sentinel_read_limit(41), 42);
+        assert_eq!(stdin_sentinel_read_limit(u64::MAX), u64::MAX);
     }
 }

--- a/crates/git-smee-cli/src/main.rs
+++ b/crates/git-smee-cli/src/main.rs
@@ -1,31 +1,16 @@
-use std::{
-    env,
-    io::{self, IsTerminal, Read},
-    path::{Path, PathBuf},
-    str::FromStr,
-};
+use std::path::{Path, PathBuf};
 
-use clap::{Parser, ValueEnum};
-use git_smee_core::{
-    config::{self, LifeCyclePhase},
-    executor,
-    installer::{self, HookInstaller, HookScriptOptions},
-    repository,
-};
+use clap::Parser;
+use git_smee_core::{config::LifeCyclePhase, installer, repository};
 
+mod commands;
 mod config_path;
 mod diagnostics;
 mod doctor;
 mod status;
 
-use config_path::{
-    is_default_config_path, normalize_config_path_for_hook_script, read_config_file,
-    resolve_config_path,
-};
-
-const DEFAULT_MAX_HOOK_STDIN_BYTES: u64 = 10 * 1024 * 1024;
-const HOOK_STDIN_LIMIT_ENV: &str = "GIT_SMEE_HOOK_STDIN_LIMIT_BYTES";
-const DEFAULT_HOOK_STDIN_LIMIT_DISPLAY: &str = "10 MiB";
+use commands::init::InitTemplate;
+use config_path::resolve_config_path;
 
 #[derive(clap::Parser)]
 #[command(name = "git-smee")]
@@ -86,66 +71,6 @@ enum Command {
     MigrateHooks,
 }
 
-#[derive(Clone, Debug, ValueEnum)]
-enum InitTemplate {
-    Minimal,
-    Rust,
-    NodePnpm,
-    Generic,
-}
-
-impl std::fmt::Display for InitTemplate {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let name = match self {
-            Self::Minimal => "minimal",
-            Self::Rust => "rust",
-            Self::NodePnpm => "node-pnpm",
-            Self::Generic => "generic",
-        };
-        formatter.write_str(name)
-    }
-}
-
-impl InitTemplate {
-    fn config_content(&self) -> Result<String, config::Error> {
-        match self {
-            Self::Minimal => (&config::SmeeConfig::default()).try_into(),
-            Self::Rust => Ok(RUST_INIT_TEMPLATE.to_string()),
-            Self::NodePnpm => Ok(NODE_PNPM_INIT_TEMPLATE.to_string()),
-            Self::Generic => Ok(GENERIC_INIT_TEMPLATE.to_string()),
-        }
-    }
-}
-
-const RUST_INIT_TEMPLATE: &str = r#"# Rust starter: edit commands to match your workspace policy.
-[[pre-commit]]
-command = "cargo fmt --all -- --check"
-
-[[pre-commit]]
-command = "cargo clippy --workspace --all-targets --all-features -- -D warnings"
-
-[[pre-push]]
-command = "cargo test --workspace --all-targets --all-features"
-"#;
-
-const NODE_PNPM_INIT_TEMPLATE: &str = r#"# Node/pnpm starter: commands are explicit and editable.
-[[pre-commit]]
-command = "pnpm lint"
-
-[[pre-push]]
-command = "pnpm test"
-"#;
-
-const GENERIC_INIT_TEMPLATE: &str = r#"# Generic starter: replace these commands with your project's checks.
-# Add another [[pre-commit]] or [[pre-push]] table for each command to run.
-[[pre-commit]]
-command = "echo 'replace me with your pre-commit check'"
-
-# Example:
-# [[pre-push]]
-# command = "./scripts/test"
-"#;
-
 fn main() {
     if let Err(error) = run() {
         eprintln!("Error: {error}");
@@ -155,58 +80,16 @@ fn main() {
 
 fn run() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
-    let invocation_dir = env::current_dir()?;
+    let invocation_dir = std::env::current_dir()?;
     let config_path = resolve_config_path(cli.config, &invocation_dir);
 
     match cli.command {
-        Command::Install { force } => {
-            repository::ensure_in_repo_root()?;
-            let installer = installer::FileSystemHookInstaller::from_default_with_force(force)?;
-            let config_path_for_hooks =
-                normalize_config_path_for_hook_script(&config_path, &env::current_dir()?)?;
-            let hook_script_options =
-                HookScriptOptions::new(env::current_exe()?, config_path_for_hooks);
-            println!("Installing hooks...");
-            let config = read_config_file(&config_path)?;
-            installer::install_hooks_with_options(&config, &installer, &hook_script_options)?;
-            println!("Hooks installed successfully.");
-            Ok(())
-        }
+        Command::Install { force } => commands::install::run_install(&config_path, force),
         Command::Run { hook, hook_args } => {
-            repository::ensure_in_repo_root()?;
-            let phase = LifeCyclePhase::from_str(&hook)?;
-            let stdin_payload = read_hook_stdin_for_phase(phase)?;
-            let config = read_config_file(&config_path)?;
-            let summary = executor::execute_hook_with_summary(
-                &config,
-                phase,
-                &hook_args,
-                stdin_payload.as_deref(),
-            )?;
-            for line in summary.text_lines(phase) {
-                println!("{line}");
-            }
-            if let Some(error) = summary.error() {
-                return Err(Box::new(error));
-            }
-            Ok(())
+            commands::run::run_hook(&config_path, &hook, &hook_args)
         }
         Command::Initialize { force, template } => {
-            repository::ensure_in_repo_root()?;
-            let installer = installer::FileSystemHookInstaller::from_default_with_force(force)?;
-            println!(
-                "Initializing {} configuration file...",
-                config_path.display()
-            );
-            let template_config = template.config_content()?;
-            let template_config = installer::with_managed_header(&template_config);
-
-            if is_default_config_path(&config_path, &env::current_dir()?) {
-                installer.install_config_file(&template_config)?;
-            } else {
-                installer::write_config_file(&config_path, &template_config, force)?;
-            }
-            Ok(())
+            commands::init::run_init(&config_path, force, &template)
         }
         Command::Doctor { json } => doctor::run_doctor(&config_path, json),
         Command::Status { json } => status::run_status(&config_path, json),
@@ -302,59 +185,4 @@ fn finish_lines(lines: Vec<String>) -> String {
     let mut output = lines.join("\n");
     output.push('\n');
     output
-}
-
-fn read_hook_stdin_for_phase(phase: LifeCyclePhase) -> io::Result<Option<Vec<u8>>> {
-    // proc-receive is an interactive pkt-line protocol: Git waits for the hook to
-    // answer before closing stdin, so buffering until EOF would deadlock before
-    // the configured command is spawned. Let the command inherit stdin instead.
-    if phase == LifeCyclePhase::ProcReceive {
-        return Ok(None);
-    }
-    read_hook_stdin()
-}
-
-fn read_hook_stdin() -> io::Result<Option<Vec<u8>>> {
-    let stdin = io::stdin();
-    if stdin.is_terminal() {
-        return Ok(None);
-    }
-
-    let max_hook_stdin_bytes = max_hook_stdin_bytes()?;
-    let mut payload = Vec::new();
-    stdin
-        .lock()
-        .take(max_hook_stdin_bytes + 1)
-        .read_to_end(&mut payload)?;
-    if payload.len() as u64 > max_hook_stdin_bytes {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!(
-                "hook stdin exceeds the {} limit",
-                hook_stdin_limit_display(max_hook_stdin_bytes)
-            ),
-        ));
-    }
-    Ok(Some(payload))
-}
-
-fn max_hook_stdin_bytes() -> io::Result<u64> {
-    let Some(value) = env::var_os(HOOK_STDIN_LIMIT_ENV) else {
-        return Ok(DEFAULT_MAX_HOOK_STDIN_BYTES);
-    };
-    let value = value.to_string_lossy();
-    value.parse::<u64>().map_err(|error| {
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("{HOOK_STDIN_LIMIT_ENV} must be an unsigned byte count: {error}"),
-        )
-    })
-}
-
-fn hook_stdin_limit_display(limit: u64) -> String {
-    if limit == DEFAULT_MAX_HOOK_STDIN_BYTES {
-        DEFAULT_HOOK_STDIN_LIMIT_DISPLAY.to_string()
-    } else {
-        format!("{limit} bytes")
-    }
 }


### PR DESCRIPTION
## Summary
- Extract `install`, `init`, and `run` command orchestration from `main.rs` into focused `commands` modules.
- Move init template ownership and hook stdin buffering helpers behind the command-handler boundary.
- Keep `main.rs` responsible for CLI parsing, config path resolution, and top-level dispatch while preserving command behavior.

Refs #164

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`
- Manual smoke in a temporary Git repository: `git smee init`, `git smee install`, `git smee doctor`, `git smee doctor --json`, `git smee status`, `git smee status --json`; parsed JSON status values were `ok`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI support for initializing configs with selectable templates.
  * Added a dedicated install command with progress messages.
  * Added a hook-run command that handles hook input and reports execution results.

* **Bug Fixes**
  * Improved validation so commands must run from the repository root.
  * Added limits for hook input size to prevent unexpectedly large payloads.

* **Refactor**
  * Simplified the main CLI entrypoint by moving command logic into separate command handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->