### PR TITLE
refactor(cli): extract migrate-hooks command

### DIFF
--- a/crates/git-smee-cli/src/commands/migrate_hooks.rs
+++ b/crates/git-smee-cli/src/commands/migrate_hooks.rs
@@ -1,0 +1,114 @@
+use std::path::Path;
+
+use git_smee_core::{config::LifeCyclePhase, installer, repository};
+
+pub(crate) fn run_migrate_hooks() -> Result<(), Box<dyn std::error::Error>> {
+    repository::ensure_in_repo_root()?;
+    let installer = installer::FileSystemHookInstaller::from_default()?;
+    let report = MigrationReport::from_hooks_dir(installer.effective_hooks_dir())?;
+
+    println!("{}", report.to_toml_suggestions());
+    Ok(())
+}
+
+#[derive(Debug, Default)]
+struct MigrationReport {
+    unmanaged_hooks: Vec<LifeCyclePhase>,
+    managed_hooks: Vec<LifeCyclePhase>,
+}
+
+impl MigrationReport {
+    fn from_hooks_dir(hooks_dir: &Path) -> Result<Self, installer::Error> {
+        let mut report = Self::default();
+
+        for phase in LifeCyclePhase::all() {
+            let hook_path = hooks_dir.join(phase.as_str());
+            if !hook_path.is_file() {
+                continue;
+            }
+
+            if installer::has_managed_header(&hook_path)? {
+                report.managed_hooks.push(*phase);
+            } else {
+                report.unmanaged_hooks.push(*phase);
+            }
+        }
+
+        Ok(report)
+    }
+
+    fn to_toml_suggestions(&self) -> String {
+        let mut lines = vec![
+            "# git-smee hook migration suggestions".to_string(),
+            "# Review these commands before adding them to .git-smee.toml.".to_string(),
+            "# Dry-run only: this command does not modify hook files or configuration.".to_string(),
+        ];
+
+        if !self.managed_hooks.is_empty() {
+            lines.push(format!(
+                "# Ignored managed git-smee hooks: {}",
+                join_phase_names(&self.managed_hooks)
+            ));
+        }
+
+        if self.unmanaged_hooks.is_empty() {
+            lines.push("# No unmanaged Git hooks found.".to_string());
+            return finish_lines(lines);
+        }
+
+        lines.push(String::new());
+        for phase in &self.unmanaged_hooks {
+            lines.push(format!("[[{}]]", phase.as_str()));
+            lines.push(format!(
+                "command = \"{}\"",
+                toml_escape_basic_string(&format!(".git-smee/legacy/{}", phase.as_str()))
+            ));
+            lines.push(format!(
+                "# TODO: move .git/hooks/{0} to .git-smee/legacy/{0} before running git smee install.",
+                phase.as_str()
+            ));
+            lines.push(String::new());
+        }
+
+        finish_lines(lines)
+    }
+}
+
+fn join_phase_names(phases: &[LifeCyclePhase]) -> String {
+    phases
+        .iter()
+        .map(|phase| phase.as_str())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn toml_escape_basic_string(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn finish_lines(lines: Vec<String>) -> String {
+    let mut output = lines.join("\n");
+    output.push('\n');
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_unmanaged_hooks_reports_no_suggestions() {
+        let report = MigrationReport::default();
+
+        assert!(
+            report
+                .to_toml_suggestions()
+                .contains("# No unmanaged Git hooks found.")
+        );
+    }
+
+    #[test]
+    fn suggestions_escape_toml_basic_strings() {
+        assert_eq!(toml_escape_basic_string(r#"a\b"c"#), r#"a\\b\"c"#);
+    }
+}

--- a/crates/git-smee-cli/src/commands/mod.rs
+++ b/crates/git-smee-cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod init;
 pub(crate) mod install;
+pub(crate) mod migrate_hooks;
 pub(crate) mod run;

--- a/crates/git-smee-cli/src/main.rs
+++ b/crates/git-smee-cli/src/main.rs
@@ -1,7 +1,6 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use clap::Parser;
-use git_smee_core::{config::LifeCyclePhase, installer, repository};
 
 mod commands;
 mod config_path;
@@ -93,96 +92,6 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         }
         Command::Doctor { json } => doctor::run_doctor(&config_path, json),
         Command::Status { json } => status::run_status(&config_path, json),
-        Command::MigrateHooks => run_migrate_hooks(),
+        Command::MigrateHooks => commands::migrate_hooks::run_migrate_hooks(),
     }
-}
-
-fn run_migrate_hooks() -> Result<(), Box<dyn std::error::Error>> {
-    repository::ensure_in_repo_root()?;
-    let installer = installer::FileSystemHookInstaller::from_default()?;
-    let report = MigrationReport::from_hooks_dir(installer.effective_hooks_dir())?;
-
-    println!("{}", report.to_toml_suggestions());
-    Ok(())
-}
-
-#[derive(Debug, Default)]
-struct MigrationReport {
-    unmanaged_hooks: Vec<LifeCyclePhase>,
-    managed_hooks: Vec<LifeCyclePhase>,
-}
-
-impl MigrationReport {
-    fn from_hooks_dir(hooks_dir: &Path) -> Result<Self, installer::Error> {
-        let mut report = Self::default();
-
-        for phase in LifeCyclePhase::all() {
-            let hook_path = hooks_dir.join(phase.as_str());
-            if !hook_path.is_file() {
-                continue;
-            }
-
-            if installer::has_managed_header(&hook_path)? {
-                report.managed_hooks.push(*phase);
-            } else {
-                report.unmanaged_hooks.push(*phase);
-            }
-        }
-
-        Ok(report)
-    }
-
-    fn to_toml_suggestions(&self) -> String {
-        let mut lines = vec![
-            "# git-smee hook migration suggestions".to_string(),
-            "# Review these commands before adding them to .git-smee.toml.".to_string(),
-            "# Dry-run only: this command does not modify hook files or configuration.".to_string(),
-        ];
-
-        if !self.managed_hooks.is_empty() {
-            lines.push(format!(
-                "# Ignored managed git-smee hooks: {}",
-                join_phase_names(&self.managed_hooks)
-            ));
-        }
-
-        if self.unmanaged_hooks.is_empty() {
-            lines.push("# No unmanaged Git hooks found.".to_string());
-            return finish_lines(lines);
-        }
-
-        lines.push(String::new());
-        for phase in &self.unmanaged_hooks {
-            lines.push(format!("[[{}]]", phase.as_str()));
-            lines.push(format!(
-                "command = \"{}\"",
-                toml_escape_basic_string(&format!(".git-smee/legacy/{}", phase.as_str()))
-            ));
-            lines.push(format!(
-                "# TODO: move .git/hooks/{0} to .git-smee/legacy/{0} before running git smee install.",
-                phase.as_str()
-            ));
-            lines.push(String::new());
-        }
-
-        finish_lines(lines)
-    }
-}
-
-fn join_phase_names(phases: &[LifeCyclePhase]) -> String {
-    phases
-        .iter()
-        .map(|phase| phase.as_str())
-        .collect::<Vec<_>>()
-        .join(", ")
-}
-
-fn toml_escape_basic_string(value: &str) -> String {
-    value.replace('\\', "\\\\").replace('"', "\\\"")
-}
-
-fn finish_lines(lines: Vec<String>) -> String {
-    let mut output = lines.join("\n");
-    output.push('\n');
-    output
 }


### PR DESCRIPTION
## Summary
- Extract `migrate-hooks` orchestration and report rendering from `main.rs` into `commands::migrate_hooks`.
- Keep `main.rs` as a thin CLI parser/config resolver/top-level dispatcher.
- Add focused unit coverage for the migrated report helpers while preserving existing CLI integration behavior.

Fixes #164

## Validation
- `cargo test -p git-smee-cli migrate_hooks -- --nocapture` (baseline before refactor and after refactor)
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`
- Manual temporary repository smoke: `git smee init`, `install`, `doctor`, `doctor --json`, `status`, `status --json`; parsed JSON statuses were `ok`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `migrate-hooks` CLI command that scans existing git-smee hook files and generates migration guidance.
  * Outputs TOML snippets for unmanaged hooks and marks managed hooks as already handled.
  * Improves generated output formatting, including proper escaping and clean newline handling.

* **Tests**
  * Added coverage for migration output when no unmanaged hooks are found.
  * Added coverage for escaping special characters in generated TOML.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->