### PR TITLE
fix: disable delayed expansion in Windows hooks

### DIFF
--- a/crates/git-smee-core/src/installer.rs
+++ b/crates/git-smee-core/src/installer.rs
@@ -963,6 +963,23 @@ mod tests {
         assert!(template.contains("embedded git-smee executable is not available"));
     }
 
+    #[test]
+    fn windows_hook_template_disables_delayed_expansion_before_embedding_paths() {
+        let template = Platform::Windows.hook_script_template();
+        let disable_position = template
+            .find("setlocal DisableDelayedExpansion")
+            .expect("windows hook template should disable delayed expansion");
+        let bin_assignment_position = template
+            .find("set \"GIT_SMEE_BIN=")
+            .expect("windows hook template should embed git-smee executable path");
+        let config_assignment_position = template
+            .find("set \"GIT_SMEE_CONFIG=")
+            .expect("windows hook template should embed config path");
+
+        assert!(disable_position < bin_assignment_position);
+        assert!(disable_position < config_assignment_position);
+    }
+
     #[cfg(unix)]
     #[test]
     fn given_special_paths_when_installing_hooks_then_unix_hook_contains_escaped_values() {

--- a/crates/git-smee-core/src/scripts/hook_template_windows
+++ b/crates/git-smee-core/src/scripts/hook_template_windows
@@ -1,6 +1,9 @@
 @echo off
 REM DO NOT MODIFY THIS FILE DIRECTLY
 REM THIS FILE IS MANAGED BY git-smee
+REM Keep literal ! characters in embedded paths stable even when the
+REM parent cmd.exe was launched with delayed expansion enabled (/V:ON).
+setlocal DisableDelayedExpansion
 
 set "GIT_SMEE_BIN={git_smee_executable}"
 set "GIT_SMEE_CONFIG={config_path}"


### PR DESCRIPTION
## Summary
- disable delayed expansion at the top of generated Windows hook wrappers so embedded paths containing `!` remain literal under `cmd /V:ON`
- add a regression test that verifies the template disables delayed expansion before assigning embedded paths

Fixes #100

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p git-smee-core windows_hook_template_disables_delayed_expansion_before_embedding_paths`
