### PR TITLE
Support multi-arch Homebrew tap updates

### DIFF
--- a/.github/scripts/test_update_homebrew_formula.py
+++ b/.github/scripts/test_update_homebrew_formula.py
@@ -1,0 +1,45 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import update_homebrew_formula
+
+
+CHECKSUMS = {
+    "git-smee-v1.2.3-aarch64-apple-darwin.tar.gz": "a" * 64,
+    "git-smee-v1.2.3-x86_64-apple-darwin.tar.gz": "b" * 64,
+    "git-smee-v1.2.3-x86_64-unknown-linux-gnu.tar.gz": "c" * 64,
+}
+
+
+class HomebrewFormulaRenderingTests(unittest.TestCase):
+    def test_render_formula_includes_each_supported_platform_url_and_checksum(self):
+        formula = update_homebrew_formula.render_formula("v1.2.3", CHECKSUMS)
+
+        self.assertIn('version "1.2.3"', formula)
+        self.assertIn("on_macos do", formula)
+        self.assertIn("on_linux do", formula)
+        self.assertIn("on_arm do", formula)
+        self.assertIn("on_intel do", formula)
+
+        for asset, checksum in CHECKSUMS.items():
+            self.assertIn(
+                f"https://github.com/errfld/git-smee/releases/download/v1.2.3/{asset}",
+                formula,
+            )
+            self.assertIn(f'sha256 "{checksum}"', formula)
+
+    def test_load_checksums_rejects_missing_targets(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            checksum_dir = Path(tmp)
+            (checksum_dir / "git-smee-v1.2.3-aarch64-apple-darwin.tar.gz.sha256").write_text(
+                f"{'a' * 64}  git-smee-v1.2.3-aarch64-apple-darwin.tar.gz\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "missing Homebrew checksum assets"):
+                update_homebrew_formula.load_checksums("v1.2.3", checksum_dir)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_update_homebrew_formula.py
+++ b/.github/scripts/test_update_homebrew_formula.py
@@ -40,6 +40,13 @@ class HomebrewFormulaRenderingTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "missing Homebrew checksum assets"):
                 update_homebrew_formula.load_checksums("v1.2.3", checksum_dir)
 
+    def test_version_from_tag_matches_release_workflow_suffixes(self):
+        accepted_tags = ["v1.2.3-rc-1", "v1.2.3-beta+build5", "v1.2.3-beta_1"]
+
+        for tag in accepted_tags:
+            with self.subTest(tag=tag):
+                self.assertEqual(tag.removeprefix("v"), update_homebrew_formula.version_from_tag(tag))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/update_homebrew_formula.py
+++ b/.github/scripts/update_homebrew_formula.py
@@ -18,6 +18,7 @@ SUPPORTED_TARGETS = (
     "x86_64-apple-darwin",
     "x86_64-unknown-linux-gnu",
 )
+RELEASE_TAG_PATTERN = re.compile(r"^v[0-9]+(\.[0-9]+)*([-.].*)?$")
 
 
 def asset_name(tag: str, target: str) -> str:
@@ -25,7 +26,7 @@ def asset_name(tag: str, target: str) -> str:
 
 
 def version_from_tag(tag: str) -> str:
-    if not re.fullmatch(r"v[0-9]+(\.[0-9]+)*([-.][0-9A-Za-z.]+)?", tag):
+    if not RELEASE_TAG_PATTERN.fullmatch(tag):
         raise ValueError(f"invalid release tag: {tag!r}")
     return tag.removeprefix("v")
 

--- a/.github/scripts/update_homebrew_formula.py
+++ b/.github/scripts/update_homebrew_formula.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Render the Homebrew tap formula for git-smee release assets.
+
+The release workflow builds binary tarballs for the Homebrew-supported Unix
+platforms, downloads their .sha256 sidecars, and uses this script to write the
+tap formula in one deterministic update.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+REPO = "errfld/git-smee"
+SUPPORTED_TARGETS = (
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-linux-gnu",
+)
+
+
+def asset_name(tag: str, target: str) -> str:
+    return f"git-smee-{tag}-{target}.tar.gz"
+
+
+def version_from_tag(tag: str) -> str:
+    if not re.fullmatch(r"v[0-9]+(\.[0-9]+)*([-.][0-9A-Za-z.]+)?", tag):
+        raise ValueError(f"invalid release tag: {tag!r}")
+    return tag.removeprefix("v")
+
+
+def load_checksums(tag: str, checksum_dir: Path) -> dict[str, str]:
+    checksums: dict[str, str] = {}
+    for target in SUPPORTED_TARGETS:
+        asset = asset_name(tag, target)
+        checksum_file = checksum_dir / f"{asset}.sha256"
+        if not checksum_file.exists():
+            continue
+        first_line = checksum_file.read_text(encoding="utf-8").splitlines()[0]
+        checksum, _, filename = first_line.partition("  ")
+        if filename != asset:
+            raise ValueError(
+                f"checksum file {checksum_file} names {filename!r}, expected {asset!r}"
+            )
+        if not re.fullmatch(r"[0-9a-fA-F]{64}", checksum):
+            raise ValueError(f"invalid sha256 in {checksum_file}: {checksum!r}")
+        checksums[asset] = checksum.lower()
+
+    missing = [
+        asset_name(tag, target)
+        for target in SUPPORTED_TARGETS
+        if asset_name(tag, target) not in checksums
+    ]
+    if missing:
+        missing_list = ", ".join(missing)
+        raise ValueError(f"missing Homebrew checksum assets: {missing_list}")
+    return checksums
+
+
+def url(tag: str, target: str) -> str:
+    return f"https://github.com/{REPO}/releases/download/{tag}/{asset_name(tag, target)}"
+
+
+def render_formula(tag: str, checksums: dict[str, str]) -> str:
+    version = version_from_tag(tag)
+    mac_arm = asset_name(tag, "aarch64-apple-darwin")
+    mac_intel = asset_name(tag, "x86_64-apple-darwin")
+    linux_intel = asset_name(tag, "x86_64-unknown-linux-gnu")
+
+    return f'''class GitSmee < Formula
+  desc "Git hook manager"
+  homepage "https://github.com/{REPO}"
+  version "{version}"
+
+  on_macos do
+    on_arm do
+      url "{url(tag, "aarch64-apple-darwin")}"
+      sha256 "{checksums[mac_arm]}"
+    end
+
+    on_intel do
+      url "{url(tag, "x86_64-apple-darwin")}"
+      sha256 "{checksums[mac_intel]}"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "{url(tag, "x86_64-unknown-linux-gnu")}"
+      sha256 "{checksums[linux_intel]}"
+    end
+  end
+
+  def install
+    bin.install "git-smee"
+  end
+
+  test do
+    system "#{{bin}}/git-smee", "--help"
+  end
+end
+'''
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True, help="release tag, e.g. v0.0.4")
+    parser.add_argument("--checksum-dir", required=True, type=Path)
+    parser.add_argument("--formula", required=True, type=Path)
+    args = parser.parse_args()
+
+    checksums = load_checksums(args.tag, args.checksum_dir)
+    args.formula.write_text(render_formula(args.tag, checksums), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: macos-latest
             target: aarch64-apple-darwin
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,8 @@ jobs:
       TAG: ${{ needs.prepare-release.outputs.tag }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Download Homebrew release checksums
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,8 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: macos-latest
             target: aarch64-apple-darwin
+          - os: macos-13
+            target: x86_64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc
     steps:
@@ -84,6 +86,7 @@ jobs:
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
+          targets: ${{ matrix.target }}
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -176,15 +179,49 @@ jobs:
     needs: [prepare-release, build-and-release]
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      TAG: ${{ needs.prepare-release.outputs.tag }}
     steps:
-      - name: Update Homebrew Tap (Apple Silicon)
-        uses: mislav/bump-homebrew-formula-action@ccf2332299a883f6af50a1d2d41e5df7904dd769 # v4.1
-        with:
-          homebrew-tap: errfld/homebrew-git-smee
-          formula-name: git-smee
-          tag-name: ${{ needs.prepare-release.outputs.tag }}
-          # This action can only bump a single URL field, so the tap remains
-          # Apple Silicon-specific until the formula moves to a multi-arch flow.
-          download-url: https://github.com/errfld/git-smee/releases/download/${{ needs.prepare-release.outputs.tag }}/git-smee-${{ needs.prepare-release.outputs.tag }}-aarch64-apple-darwin.tar.gz
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Download Homebrew release checksums
+        shell: bash
         env:
-          COMMITTER_TOKEN: ${{ secrets.HOMEBREW_PAT }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p homebrew-checksums
+          gh release download "$TAG" \
+            --repo errfld/git-smee \
+            --dir homebrew-checksums \
+            --pattern "git-smee-$TAG-aarch64-apple-darwin.tar.gz.sha256" \
+            --pattern "git-smee-$TAG-x86_64-apple-darwin.tar.gz.sha256" \
+            --pattern "git-smee-$TAG-x86_64-unknown-linux-gnu.tar.gz.sha256"
+
+      - name: Check out Homebrew tap
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: errfld/homebrew-git-smee
+          token: ${{ secrets.HOMEBREW_PAT }}
+          path: homebrew-tap
+
+      - name: Render multi-arch Homebrew formula
+        shell: bash
+        run: |
+          python3 .github/scripts/update_homebrew_formula.py \
+            --tag "$TAG" \
+            --checksum-dir homebrew-checksums \
+            --formula homebrew-tap/Formula/git-smee.rb
+
+      - name: Commit Homebrew tap update
+        shell: bash
+        working-directory: homebrew-tap
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/git-smee.rb
+          if git diff --cached --quiet; then
+            echo "Homebrew formula already up to date for $TAG"
+            exit 0
+          fi
+          git commit -m "Update git-smee to $TAG"
+          git push

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ brew tap errfld/git-smee
 brew install git-smee
 ```
 
-The Homebrew tap currently publishes the Apple Silicon (`aarch64-apple-darwin`) release artifact.
+The Homebrew tap installs prebuilt release artifacts for Apple Silicon macOS (`aarch64-apple-darwin`), Intel macOS (`x86_64-apple-darwin`), and Intel Linuxbrew (`x86_64-unknown-linux-gnu`).
 
 ### Cargo
 


### PR DESCRIPTION
## Summary
- add an Intel macOS release artifact so the release matrix covers Apple Silicon macOS, Intel macOS, and Intel Linuxbrew
- replace the single-URL Homebrew bump action with a deterministic tap formula renderer that updates all supported binary URLs/checksums together
- document the resulting Homebrew support matrix in the README

Fixes #120

## Validation
- RED: `python3 .github/scripts/test_update_homebrew_formula.py` failed before the renderer existed with `ModuleNotFoundError`
- GREEN: `python3 .github/scripts/test_update_homebrew_formula.py`
- GREEN: `python3 -m py_compile .github/scripts/update_homebrew_formula.py .github/scripts/test_update_homebrew_formula.py`
- GREEN: rendered-formula smoke test with synthetic checksum sidecars
- GREEN: release workflow structural smoke test for multi-arch Homebrew fragments
- GREEN: `git diff --check`
- GREEN: `cargo fmt --all -- --check`
- GREEN: `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- GREEN: `cargo test --workspace --all-targets --all-features`

Note: `actionlint` is not installed on this runner, and `npx --yes actionlint .github/workflows/release.yml` failed because npm could not determine an executable package to run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Homebrew installs now cover prebuilt releases for Apple Silicon macOS, Intel macOS, and Intel Linux.
  * Release automation now updates the Homebrew formula with multiple platform downloads and checksums.

* **Bug Fixes**
  * Improved release packaging to better match the target platform being built.

* **Tests**
  * Added checks to verify the generated Homebrew formula and required checksum files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->