### PR TITLE
fix(hooks): make Windows hooks shell-invokable

### DIFF
--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -545,7 +545,7 @@ fn given_install_when_generating_hook_script_then_wrapper_forwards_hook_argument
     assert!(hook_content.contains("run pre-commit \"$@\""));
 
     #[cfg(windows)]
-    assert!(hook_content.contains("run pre-commit %*"));
+    assert!(hook_content.contains("run pre-commit \"$@\""));
 }
 
 #[cfg(windows)]

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -580,10 +580,6 @@ for ($i = 1; $i -le [int]$env:GIT_SMEE_HOOK_ARGC; $i++) {{
         .success();
 
     let hook = test_repo.path.join(".git/hooks/commit-msg");
-    // Copy the generated wrapper to a .bat path so this #112 regression isolates
-    // argument forwarding from #176's no-extension Git-for-Windows spawn gap.
-    let hook_bat = test_repo.path.join("commit-msg-wrapper.bat");
-    fs::copy(&hook, &hook_bat).expect("failed to make batch-executable wrapper copy");
     let args = [
         "alpha&bravo",
         "pipe|value",
@@ -591,24 +587,12 @@ for ($i = 1; $i -le [int]$env:GIT_SMEE_HOOK_ARGC; $i++) {{
         "paren(value)",
         "space value",
     ];
-    let hook_for_cmd = hook_bat.to_string_lossy().replace('"', "\"\"");
-    let quoted_args = args
-        .iter()
-        .map(|arg| quote_windows_cmd_arg(arg))
-        .collect::<Vec<_>>()
-        .join(" ");
-    let driver = test_repo.path.join("invoke-metachar-wrapper.cmd");
-    fs::write(
-        &driver,
-        format!("@echo off\r\ncall \"{hook_for_cmd}\" {quoted_args}\r\nexit /b %ERRORLEVEL%\r\n"),
-    )
-    .expect("failed to write wrapper driver");
-    let status = StdCommand::new("cmd")
+    let status = StdCommand::new("sh")
         .current_dir(&test_repo.path)
-        .args(["/V:ON", "/C"])
-        .arg(&driver)
+        .arg(&hook)
+        .args(args)
         .status()
-        .expect("failed to run Windows hook wrapper through cmd.exe");
+        .expect("failed to run Windows hook wrapper through sh");
     assert!(status.success(), "installed hook wrapper failed: {status}");
 
     let mut expected = vec![args.len().to_string()];
@@ -1663,16 +1647,6 @@ fn normalize_test_newlines(value: &str) -> String {
     value.replace("\r\n", "\n")
 }
 
-#[cfg(windows)]
-fn quote_windows_cmd_arg(arg: &str) -> String {
-    let escaped = arg
-        .replace('^', "^^")
-        .replace('!', "^!")
-        .replace('%', "%%")
-        .replace('"', "\"\"");
-    format!("\"{escaped}\"")
-}
-
 #[cfg(not(windows))]
 fn normalize_test_newlines(value: &str) -> String {
     value.to_string()
@@ -1888,10 +1862,7 @@ command = "echo custom"
 
     #[cfg(windows)]
     {
-        let expected = custom_config
-            .to_string_lossy()
-            .replace('"', "\"\"")
-            .replace('%', "%%");
+        let expected = custom_config.to_string_lossy().replace('\'', "'\"'\"'");
         assert!(hook_content.contains(&expected));
     }
 }

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -37,6 +37,30 @@ fn git(test_repo: &common::TestRepo, args: &[&str]) {
     assert!(status.success(), "git {args:?} failed with {status}");
 }
 
+#[cfg(windows)]
+fn git_for_windows_sh(test_repo: &common::TestRepo) -> PathBuf {
+    let output = StdCommand::new("git")
+        .current_dir(&test_repo.path)
+        .arg("--exec-path")
+        .output()
+        .expect("failed to locate Git for Windows exec path");
+    assert!(output.status.success(), "git --exec-path failed");
+
+    let exec_path = String::from_utf8(output.stdout).expect("git exec path should be UTF-8");
+    let exec_path = std::path::PathBuf::from(exec_path.trim());
+    let git_root = exec_path
+        .ancestors()
+        .nth(3)
+        .expect("Git for Windows exec path should be under <Git>/mingw64/libexec/git-core");
+    let sh = git_root.join("usr").join("bin").join("sh.exe");
+    assert!(
+        sh.exists(),
+        "Git for Windows sh.exe not found at {}",
+        sh.display()
+    );
+    sh
+}
+
 #[test]
 fn given_git_smee_when_help_then_success() {
     let mut cmd = Command::new(cargo::cargo_bin!("git-smee"));
@@ -587,7 +611,8 @@ for ($i = 1; $i -le [int]$env:GIT_SMEE_HOOK_ARGC; $i++) {{
         "paren(value)",
         "space value",
     ];
-    let status = StdCommand::new("sh")
+    let sh = git_for_windows_sh(&test_repo);
+    let status = StdCommand::new(sh)
         .current_dir(&test_repo.path)
         .arg(&hook)
         .args(args)

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -38,7 +38,7 @@ fn git(test_repo: &common::TestRepo, args: &[&str]) {
 }
 
 #[cfg(windows)]
-fn git_for_windows_sh(test_repo: &common::TestRepo) -> PathBuf {
+fn git_for_windows_sh(test_repo: &common::TestRepo) -> std::path::PathBuf {
     let output = StdCommand::new("git")
         .current_dir(&test_repo.path)
         .arg("--exec-path")

--- a/crates/git-smee-core/src/installer.rs
+++ b/crates/git-smee-core/src/installer.rs
@@ -583,14 +583,8 @@ pub fn install_hooks_with_options<T: HookInstaller>(
         return Err(Error::NoHooksPresent);
     }
     let platform = Platform::current();
-    let escaped_executable = match platform {
-        Platform::Unix => shell_single_quote(&options.git_smee_executable),
-        Platform::Windows => cmd_escape(&options.git_smee_executable),
-    };
-    let escaped_config_path = match platform {
-        Platform::Unix => shell_single_quote(&options.config_path),
-        Platform::Windows => cmd_escape(&options.config_path),
-    };
+    let escaped_executable = shell_single_quote(&options.git_smee_executable);
+    let escaped_config_path = shell_single_quote(&options.config_path);
     let mut phases: Vec<_> = config.hooks.keys().copied().collect();
     phases.sort_by_key(|phase| phase.as_str());
     let active_hook_names: Vec<_> = phases.iter().map(|phase| phase.to_string()).collect();
@@ -641,12 +635,6 @@ fn unix_shell_path_word(path: &Path) -> String {
 #[cfg(not(unix))]
 fn unix_shell_path_word(path: &Path) -> String {
     format!("'{}'", path.to_string_lossy().replace('\'', "'\"'\"'"))
-}
-
-fn cmd_escape(path: &Path) -> String {
-    path.to_string_lossy()
-        .replace('"', "\"\"")
-        .replace('%', "%%")
 }
 
 #[cfg(test)]
@@ -934,16 +922,6 @@ mod tests {
     }
 
     #[test]
-    fn cmd_escape_escapes_percent_and_double_quotes() {
-        let path = Path::new(r#"C:\Program Files\100%"quoted"\git-smee.exe"#);
-
-        assert_eq!(
-            cmd_escape(path),
-            r#"C:\Program Files\100%%""quoted""\git-smee.exe"#
-        );
-    }
-
-    #[test]
     fn unix_hook_template_does_not_fall_back_to_path_when_embedded_binary_is_stale() {
         let template = Platform::Unix.hook_script_template();
 
@@ -957,27 +935,23 @@ mod tests {
     fn windows_hook_template_does_not_fall_back_to_path_when_embedded_binary_is_stale() {
         let template = Platform::Windows.hook_script_template();
 
-        assert!(!template.contains("where git-smee"));
+        assert!(!template.contains("command -v git-smee"));
         assert!(!template.contains("git-smee --config"));
         assert!(!template.contains("git smee --config"));
         assert!(template.contains("embedded git-smee executable is not available"));
     }
 
     #[test]
-    fn windows_hook_template_disables_delayed_expansion_before_embedding_paths() {
+    fn windows_hook_template_is_git_for_windows_shell_invokable() {
         let template = Platform::Windows.hook_script_template();
-        let disable_position = template
-            .find("setlocal DisableDelayedExpansion")
-            .expect("windows hook template should disable delayed expansion");
-        let bin_assignment_position = template
-            .find("set \"GIT_SMEE_BIN=")
-            .expect("windows hook template should embed git-smee executable path");
-        let config_assignment_position = template
-            .find("set \"GIT_SMEE_CONFIG=")
-            .expect("windows hook template should embed config path");
 
-        assert!(disable_position < bin_assignment_position);
-        assert!(disable_position < config_assignment_position);
+        assert!(template.starts_with("#!/usr/bin/env sh\n"));
+        assert!(template.contains("GIT_SMEE_BIN_WIN={git_smee_executable}"));
+        assert!(template.contains("GIT_SMEE_CONFIG={config_path}"));
+        assert!(template.contains("cygpath -u \"$GIT_SMEE_BIN_WIN\""));
+        assert!(template.contains("run {hook} \"$@\""));
+        assert!(!template.contains("@echo off"));
+        assert!(!template.contains("%*"));
     }
 
     #[cfg(unix)]
@@ -1024,16 +998,19 @@ mod tests {
             PathBuf::from(r#"C:\Program Files\100%"quoted"\git-smee.exe"#),
             PathBuf::from(r#"C:\repo\configs\it's 100% "ready".toml"#),
         );
-        let installer =
-            AssertingHookInstaller::new(|hook_name, hook_content| {
-                assert_eq!(hook_name, "pre-commit");
-                assert!(hook_content.contains(
-                    r#"set "GIT_SMEE_BIN=C:\Program Files\100%%""quoted""\git-smee.exe""#
-                ));
-                assert!(hook_content.contains(
-                    r#"set "GIT_SMEE_CONFIG=C:\repo\configs\it's 100%% ""ready"".toml""#
-                ));
-            });
+        let installer = AssertingHookInstaller::new(|hook_name, hook_content| {
+            assert_eq!(hook_name, "pre-commit");
+            assert!(hook_content.starts_with("#!/usr/bin/env sh\n"));
+            assert!(
+                hook_content
+                    .contains(r#"GIT_SMEE_BIN_WIN='C:\Program Files\100%"quoted"\git-smee.exe'"#)
+            );
+            assert!(
+                hook_content.contains(
+                    "GIT_SMEE_CONFIG='C:\\repo\\configs\\it'\"'\"'s 100% \"ready\".toml'"
+                )
+            );
+        });
 
         let result = install_hooks_with_options(&config, &installer, &options);
         assert!(result.is_ok());

--- a/crates/git-smee-core/src/installer.rs
+++ b/crates/git-smee-core/src/installer.rs
@@ -945,7 +945,7 @@ mod tests {
     fn windows_hook_template_is_git_for_windows_shell_invokable() {
         let template = Platform::Windows.hook_script_template();
 
-        assert!(template.starts_with("#!/usr/bin/env sh\n"));
+        assert!(template.starts_with("#!/usr/bin/env sh"));
         assert!(template.contains("GIT_SMEE_BIN_WIN={git_smee_executable}"));
         assert!(template.contains("GIT_SMEE_CONFIG={config_path}"));
         assert!(template.contains("cygpath -u \"$GIT_SMEE_BIN_WIN\""));
@@ -1000,7 +1000,7 @@ mod tests {
         );
         let installer = AssertingHookInstaller::new(|hook_name, hook_content| {
             assert_eq!(hook_name, "pre-commit");
-            assert!(hook_content.starts_with("#!/usr/bin/env sh\n"));
+            assert!(hook_content.starts_with("#!/usr/bin/env sh"));
             assert!(
                 hook_content
                     .contains(r#"GIT_SMEE_BIN_WIN='C:\Program Files\100%"quoted"\git-smee.exe'"#)

--- a/crates/git-smee-core/src/scripts/hook_template_windows
+++ b/crates/git-smee-core/src/scripts/hook_template_windows
@@ -1,17 +1,22 @@
-@echo off
-REM DO NOT MODIFY THIS FILE DIRECTLY
-REM THIS FILE IS MANAGED BY git-smee
-REM Keep literal ! characters in embedded paths stable even when the
-REM parent cmd.exe was launched with delayed expansion enabled (/V:ON).
-setlocal DisableDelayedExpansion
+#!/usr/bin/env sh
+# DO NOT MODIFY THIS FILE DIRECTLY
+# THIS FILE IS MANAGED BY git-smee
 
-set "GIT_SMEE_BIN={git_smee_executable}"
-set "GIT_SMEE_CONFIG={config_path}"
+set -e
 
-if not exist "%GIT_SMEE_BIN%" (
-  echo git-smee: embedded git-smee executable is not available: "%GIT_SMEE_BIN%" 1>&2
-  echo git-smee: run "git smee install" again to refresh this hook wrapper. 1>&2
-  exit /b 127
-)
+GIT_SMEE_BIN_WIN={git_smee_executable}
+GIT_SMEE_CONFIG={config_path}
 
-"%GIT_SMEE_BIN%" --config "%GIT_SMEE_CONFIG%" run {hook} %*
+if command -v cygpath >/dev/null 2>&1; then
+  GIT_SMEE_BIN=$(cygpath -u "$GIT_SMEE_BIN_WIN")
+else
+  GIT_SMEE_BIN=$GIT_SMEE_BIN_WIN
+fi
+
+if [ ! -f "$GIT_SMEE_BIN" ]; then
+  echo "git-smee: embedded git-smee executable is not available: $GIT_SMEE_BIN_WIN" >&2
+  echo "git-smee: run 'git smee install' again to refresh this hook wrapper." >&2
+  exit 127
+fi
+
+exec "$GIT_SMEE_BIN" --config "$GIT_SMEE_CONFIG" run {hook} "$@"


### PR DESCRIPTION
## Summary
- replace the Windows no-extension hook body with a Git-for-Windows shell-invokable shim
- quote embedded executable/config paths with the existing shell quoting path and convert the executable path through `cygpath` when available
- update hook-template regression coverage so Windows installed hooks forward `"$@"` like Git's shell hook runner

Fixes #176

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows hook wrappers now run through a shell script instead of a batch file, improving how hook commands are launched.
  * Hook arguments are now forwarded more reliably on Windows, including special characters.

* **Bug Fixes**
  * Updated Windows path handling so embedded binary and config paths are quoted more consistently.
  * Improved compatibility for Git for Windows environments by resolving paths more robustly when possible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->