### PR TITLE
refactor(core): type hook commands

### DIFF
--- a/crates/git-smee-core/src/config.rs
+++ b/crates/git-smee-core/src/config.rs
@@ -75,7 +75,7 @@ impl SmeeConfig {
             }
 
             for (index, hook_definition) in hooks.iter().enumerate() {
-                if hook_definition.command.trim().is_empty() {
+                if hook_definition.command.is_empty() {
                     return Err(ValidationError::EmptyCommand {
                         hook_name: phase.to_string(),
                         entry_index: index + 1,
@@ -94,7 +94,7 @@ impl Default for SmeeConfig {
         hash_map.insert(
             LifeCyclePhase::PreCommit,
             vec![HookDefinition {
-                command: "echo 'Default pre-commit hook'".to_string(),
+                command: "echo 'Default pre-commit hook'".into(),
                 parallel_execution_allowed: false,
             }],
         );
@@ -121,9 +121,51 @@ impl TryFrom<&SmeeConfig> for String {
 #[derive(Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct HookDefinition {
-    pub command: String,
+    pub command: HookCommand,
     #[serde(default = "bool::default")]
     pub parallel_execution_allowed: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct HookCommand(String);
+
+impl HookCommand {
+    pub fn as_shell_source(&self) -> &str {
+        &self.0
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.trim().is_empty()
+    }
+
+    pub(crate) fn redacted(&self) -> String {
+        crate::executor::redaction::redact_command(self.as_shell_source())
+    }
+}
+
+impl From<String> for HookCommand {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for HookCommand {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl PartialEq<&str> for HookCommand {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_shell_source() == *other
+    }
+}
+
+impl PartialEq<HookCommand> for &str {
+    fn eq(&self, other: &HookCommand) -> bool {
+        *self == other.as_shell_source()
+    }
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Debug, Clone, Copy)]
@@ -422,17 +464,36 @@ mod tests {
     }
 
     #[test]
+    fn given_hook_command_when_inspecting_then_shell_source_and_redacted_display_are_owned_by_type()
+    {
+        let command = HookCommand::from("TOKEN=super-secret deploy --token hidden");
+
+        assert_eq!(
+            command.as_shell_source(),
+            "TOKEN=super-secret deploy --token hidden"
+        );
+        assert_eq!(command.redacted(), "deploy <args redacted>");
+    }
+
+    #[test]
+    fn given_whitespace_hook_command_when_checking_empty_then_command_type_rejects_it() {
+        let command = HookCommand::from("   ");
+
+        assert!(command.is_empty());
+    }
+
+    #[test]
     fn given_empty_command_when_validating_then_error_contains_hook_and_entry() {
         let mut hooks = HashMap::new();
         hooks.insert(
             LifeCyclePhase::PreCommit,
             vec![
                 HookDefinition {
-                    command: "cargo test".to_string(),
+                    command: "cargo test".into(),
                     parallel_execution_allowed: false,
                 },
                 HookDefinition {
-                    command: "   ".to_string(),
+                    command: "   ".into(),
                     parallel_execution_allowed: false,
                 },
             ],
@@ -472,7 +533,7 @@ mod tests {
         hooks.insert(
             LifeCyclePhase::PreCommit,
             vec![HookDefinition {
-                command: "cargo test".to_string(),
+                command: "cargo test".into(),
                 parallel_execution_allowed: false,
             }],
         );

--- a/crates/git-smee-core/src/executor.rs
+++ b/crates/git-smee-core/src/executor.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-mod redaction;
+pub(crate) mod redaction;
 mod runner;
 mod scheduler;
 mod summary;
@@ -145,7 +145,10 @@ mod tests {
     use assert2::assert;
     use proptest::prelude::*;
 
-    use crate::{config::HookDefinition, test_support::process_state_lock};
+    use crate::{
+        config::{HookCommand, HookDefinition},
+        test_support::process_state_lock,
+    };
 
     use super::redaction::redact_command;
     use super::runner::{
@@ -215,21 +218,26 @@ mod tests {
     impl CommandRunner for FakeRunner {
         fn run(
             &self,
-            command: &str,
+            command: &HookCommand,
             hook_args: &[String],
             stdin_payload: Option<&[u8]>,
         ) -> Result<Option<i32>, io::Error> {
             let outcome = {
                 let mut state = self.state.lock().unwrap();
-                state.calls.push(command.to_string());
+                state.calls.push(command.as_shell_source().to_string());
                 state.hook_args_calls.push(hook_args.to_vec());
                 state.stdin_calls.push(stdin_payload.map(Vec::from));
                 state
                     .outcomes_by_command
-                    .get_mut(command)
+                    .get_mut(command.as_shell_source())
                     .and_then(VecDeque::pop_front)
                     .or_else(|| state.default_outcomes.pop_front())
-                    .unwrap_or_else(|| panic!("no fake outcome configured for command '{command}'"))
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "no fake outcome configured for command '{}'",
+                            command.as_shell_source()
+                        )
+                    })
             };
             match outcome {
                 PlannedResult::Exit(code) => Ok(code),
@@ -265,7 +273,7 @@ mod tests {
         hooks_map.insert(
             LifeCyclePhase::PreCommit,
             vec![crate::config::HookDefinition {
-                command: "run-pre-commit".to_string(),
+                command: "run-pre-commit".into(),
                 parallel_execution_allowed: false,
             }],
         );
@@ -284,7 +292,7 @@ mod tests {
         hooks_map.insert(
             LifeCyclePhase::CommitMsg,
             vec![crate::config::HookDefinition {
-                command: "check-commit-message".to_string(),
+                command: "check-commit-message".into(),
                 parallel_execution_allowed: false,
             }],
         );
@@ -336,11 +344,11 @@ mod tests {
     fn given_summary_success_when_rendering_then_counts_phases_and_durations() {
         let hooks = vec![
             HookDefinition {
-                command: "seq-ok".to_string(),
+                command: "seq-ok".into(),
                 parallel_execution_allowed: false,
             },
             HookDefinition {
-                command: "parallel-ok".to_string(),
+                command: "parallel-ok".into(),
                 parallel_execution_allowed: true,
             },
         ];
@@ -375,15 +383,15 @@ mod tests {
     fn given_summary_sequential_failure_when_rendering_then_reports_skipped_and_first_failure() {
         let hooks = vec![
             HookDefinition {
-                command: "seq-fail".to_string(),
+                command: "seq-fail".into(),
                 parallel_execution_allowed: false,
             },
             HookDefinition {
-                command: "seq-skipped".to_string(),
+                command: "seq-skipped".into(),
                 parallel_execution_allowed: false,
             },
             HookDefinition {
-                command: "parallel-skipped".to_string(),
+                command: "parallel-skipped".into(),
                 parallel_execution_allowed: true,
             },
         ];
@@ -448,7 +456,7 @@ mod tests {
     #[test]
     fn given_spawn_failure_when_rendering_summary_then_status_and_error_are_redacted() {
         let hooks = vec![HookDefinition {
-            command: "SECRET=value deploy --token super-secret-value".to_string(),
+            command: "SECRET=value deploy --token super-secret-value".into(),
             parallel_execution_allowed: false,
         }];
         let runner = FakeRunner::with_default_outcomes(vec![PlannedResult::SpawnError(
@@ -479,11 +487,11 @@ mod tests {
     fn given_stdin_payload_when_executing_then_each_command_receives_the_same_bytes() {
         let hooks = vec![
             HookDefinition {
-                command: "first".to_string(),
+                command: "first".into(),
                 parallel_execution_allowed: false,
             },
             HookDefinition {
-                command: "second".to_string(),
+                command: "second".into(),
                 parallel_execution_allowed: false,
             },
         ];
@@ -624,7 +632,7 @@ mod tests {
         hooks_map.insert(
             LifeCyclePhase::PreCommit,
             vec![crate::config::HookDefinition {
-                command: "hook command".to_string(),
+                command: "hook command".into(),
                 parallel_execution_allowed: false,
             }],
         );
@@ -643,7 +651,12 @@ mod tests {
             io::ErrorKind::NotFound,
         )]);
 
-        let result = execute_command("deploy --token super-secret-value", &runner, &[], None);
+        let result = execute_command(
+            &HookCommand::from("deploy --token super-secret-value"),
+            &runner,
+            &[],
+            None,
+        );
 
         match result {
             Err(Error::CommandSpawnFailed {
@@ -666,7 +679,7 @@ mod tests {
         )]);
 
         let result = execute_command(
-            "TOKEN=super-secret API_KEY=123 deploy --arg value",
+            &HookCommand::from("TOKEN=super-secret API_KEY=123 deploy --arg value"),
             &runner,
             &[],
             None,
@@ -690,7 +703,9 @@ mod tests {
         )]);
 
         let result = execute_command(
-            "TOKEN=\"super secret\" API_KEY='another secret' ./deploy --arg value",
+            &HookCommand::from(
+                "TOKEN=\"super secret\" API_KEY='another secret' ./deploy --arg value",
+            ),
             &runner,
             &[],
             None,
@@ -754,14 +769,14 @@ mod tests {
     #[test]
     fn given_empty_command_when_executing_then_no_command_defined_error() {
         let runner = FakeRunner::with_default_outcomes(vec![]);
-        let result = execute_command("   ", &runner, &[], None);
+        let result = execute_command(&HookCommand::from("   "), &runner, &[], None);
         assert!(matches!(result, Err(Error::NoCommandDefined)));
     }
 
     #[test]
     fn given_missing_exit_code_when_executing_then_terminated_by_signal_error() {
         let runner = FakeRunner::with_default_outcomes(vec![PlannedResult::Exit(None)]);
-        let result = execute_command("run-hook", &runner, &[], None);
+        let result = execute_command(&HookCommand::from("run-hook"), &runner, &[], None);
         assert!(matches!(result, Err(Error::ExecutionTerminatedBySignal)));
     }
 
@@ -773,7 +788,7 @@ mod tests {
             ["parallel-1", "parallel-2", "parallel-3", "parallel-4"]
                 .iter()
                 .map(|command| HookDefinition {
-                    command: command.to_string(),
+                    command: (*command).into(),
                     parallel_execution_allowed: true,
                 })
                 .collect(),
@@ -809,16 +824,16 @@ mod tests {
         let mut hook_definitions: Vec<HookDefinition> = ["parallel-1", "parallel-2", "parallel-3"]
             .iter()
             .map(|command| HookDefinition {
-                command: command.to_string(),
+                command: (*command).into(),
                 parallel_execution_allowed: true,
             })
             .collect();
         hook_definitions.push(HookDefinition {
-            command: "sequential-1".to_string(),
+            command: "sequential-1".into(),
             parallel_execution_allowed: false,
         });
         hook_definitions.push(HookDefinition {
-            command: "sequential-2".to_string(),
+            command: "sequential-2".into(),
             parallel_execution_allowed: false,
         });
 
@@ -857,11 +872,11 @@ mod tests {
     fn given_failed_sequential_hook_when_executing_then_parallel_hooks_do_not_run() {
         let hooks = vec![
             HookDefinition {
-                command: "sequential".to_string(),
+                command: "sequential".into(),
                 parallel_execution_allowed: false,
             },
             HookDefinition {
-                command: "parallel".to_string(),
+                command: "parallel".into(),
                 parallel_execution_allowed: true,
             },
         ];
@@ -881,15 +896,15 @@ mod tests {
         let barrier = Arc::new(Barrier::new(2));
         let hooks = vec![
             HookDefinition {
-                command: "sequential".to_string(),
+                command: "sequential".into(),
                 parallel_execution_allowed: false,
             },
             HookDefinition {
-                command: "parallel-ok".to_string(),
+                command: "parallel-ok".into(),
                 parallel_execution_allowed: true,
             },
             HookDefinition {
-                command: "parallel-fail".to_string(),
+                command: "parallel-fail".into(),
                 parallel_execution_allowed: true,
             },
         ];

--- a/crates/git-smee-core/src/executor/redaction.rs
+++ b/crates/git-smee-core/src/executor/redaction.rs
@@ -1,4 +1,4 @@
-pub(super) fn redact_command(command: &str) -> String {
+pub(crate) fn redact_command(command: &str) -> String {
     let tokens = tokenize_command(command);
     let executable_index = tokens
         .iter()

--- a/crates/git-smee-core/src/executor/runner.rs
+++ b/crates/git-smee-core/src/executor/runner.rs
@@ -10,12 +10,12 @@ use std::os::windows::process::CommandExt;
 #[cfg(windows)]
 use std::path::PathBuf;
 
-use crate::platform::Platform;
+use crate::{config::HookCommand, platform::Platform};
 
 pub(super) trait CommandRunner: Sync {
     fn run(
         &self,
-        command: &str,
+        command: &HookCommand,
         hook_args: &[String],
         stdin_payload: Option<&[u8]>,
     ) -> Result<Option<i32>, std::io::Error>;
@@ -29,7 +29,7 @@ pub(super) struct PlatformCommandRunner<'a> {
 impl CommandRunner for PlatformCommandRunner<'_> {
     fn run(
         &self,
-        command: &str,
+        command: &HookCommand,
         hook_args: &[String],
         stdin_payload: Option<&[u8]>,
     ) -> Result<Option<i32>, std::io::Error> {
@@ -38,12 +38,12 @@ impl CommandRunner for PlatformCommandRunner<'_> {
         let mut _windows_command_script = None;
         match self.platform {
             Platform::Unix => {
-                shell_command.arg(command);
+                shell_command.arg(command.as_shell_source());
                 shell_command.arg("--");
                 shell_command.args(hook_args);
             }
             Platform::Windows => {
-                let command_script = create_windows_command_script(command)?;
+                let command_script = create_windows_command_script(command.as_shell_source())?;
                 shell_command.arg(&command_script);
                 #[cfg(windows)]
                 append_windows_hook_args(&mut shell_command, hook_args);

--- a/crates/git-smee-core/src/executor/scheduler.rs
+++ b/crates/git-smee-core/src/executor/scheduler.rs
@@ -6,11 +6,10 @@ use std::{
 use rayon::iter::IntoParallelRefIterator;
 use rayon::prelude::*;
 
-use crate::config::HookDefinition;
+use crate::config::{HookCommand, HookDefinition};
 
 use super::{
     Error,
-    redaction::redact_command,
     runner::CommandRunner,
     summary::{CommandOutcome, CommandPhase, CommandRun, HookRunSummary},
 };
@@ -112,25 +111,21 @@ fn lock_command_runs(
 fn execute_command_record(
     phase: CommandPhase,
     index: usize,
-    command: &str,
+    command: &HookCommand,
     runner: &impl CommandRunner,
     hook_args: &[String],
     stdin_payload: Option<&[u8]>,
 ) -> CommandRun {
     let started = Instant::now();
-    let outcome = if command.trim().is_empty() {
-        CommandOutcome::NoCommandDefined
-    } else {
-        match runner.run(command, hook_args, stdin_payload) {
-            Ok(Some(0)) => CommandOutcome::Success,
-            Ok(Some(exit_status_code)) => CommandOutcome::Exit(exit_status_code),
-            Ok(None) => CommandOutcome::Signal,
-            Err(source) => CommandOutcome::SpawnFailed {
-                command: redact_command(command),
-                shell: runner.shell_display().to_string(),
-                source,
-            },
-        }
+    let outcome = match runner.run(command, hook_args, stdin_payload) {
+        Ok(Some(0)) => CommandOutcome::Success,
+        Ok(Some(exit_status_code)) => CommandOutcome::Exit(exit_status_code),
+        Ok(None) => CommandOutcome::Signal,
+        Err(source) => CommandOutcome::SpawnFailed {
+            command: command.redacted(),
+            shell: runner.shell_display().to_string(),
+            source,
+        },
     };
     CommandRun {
         phase,
@@ -142,18 +137,18 @@ fn execute_command_record(
 
 #[cfg(test)]
 pub(super) fn execute_command(
-    command: &str,
+    command: &HookCommand,
     runner: &impl CommandRunner,
     hook_args: &[String],
     stdin_payload: Option<&[u8]>,
 ) -> Result<(), Error> {
-    if command.trim().is_empty() {
+    if command.is_empty() {
         return Err(Error::NoCommandDefined);
     }
     let exit_code = runner
         .run(command, hook_args, stdin_payload)
         .map_err(|source| Error::CommandSpawnFailed {
-            command: redact_command(command),
+            command: command.redacted(),
             shell: runner.shell_display().to_string(),
             source,
         })?;

--- a/crates/git-smee-core/src/executor/summary.rs
+++ b/crates/git-smee-core/src/executor/summary.rs
@@ -137,7 +137,6 @@ impl CommandRun {
             CommandOutcome::Exit(code) => format!("failed with code {code}"),
             CommandOutcome::Signal => "terminated by signal".to_string(),
             CommandOutcome::SpawnFailed { .. } => "spawn failed".to_string(),
-            CommandOutcome::NoCommandDefined => "no command defined".to_string(),
         }
     }
 
@@ -154,7 +153,6 @@ impl CommandRun {
             } => {
                 format!("{prefix} failed to spawn '{command}' via '{shell}': {source}")
             }
-            CommandOutcome::NoCommandDefined => format!("{prefix} had no command defined"),
         }
     }
 
@@ -172,7 +170,6 @@ impl CommandRun {
                 shell: shell.clone(),
                 source: io::Error::new(source.kind(), source.to_string()),
             }),
-            CommandOutcome::NoCommandDefined => Some(Error::NoCommandDefined),
         }
     }
 }
@@ -187,7 +184,6 @@ pub(super) enum CommandOutcome {
         shell: String,
         source: io::Error,
     },
-    NoCommandDefined,
 }
 
 impl CommandOutcome {

--- a/crates/git-smee-core/src/installer.rs
+++ b/crates/git-smee-core/src/installer.rs
@@ -715,7 +715,7 @@ mod tests {
         hooks_map.insert(
             crate::config::LifeCyclePhase::PreCommit,
             vec![crate::config::HookDefinition {
-                command: "echo Pre-commit hook".to_string(),
+                command: "echo Pre-commit hook".into(),
                 parallel_execution_allowed: false,
             }],
         );
@@ -749,14 +749,14 @@ mod tests {
         hooks_map.insert(
             crate::config::LifeCyclePhase::PreCommit,
             vec![crate::config::HookDefinition {
-                command: "echo Pre-commit hook".to_string(),
+                command: "echo Pre-commit hook".into(),
                 parallel_execution_allowed: false,
             }],
         );
         hooks_map.insert(
             crate::config::LifeCyclePhase::PrePush,
             vec![crate::config::HookDefinition {
-                command: "echo Pre-push hook".to_string(),
+                command: "echo Pre-push hook".into(),
                 parallel_execution_allowed: false,
             }],
         );
@@ -794,21 +794,21 @@ mod tests {
         hooks_map.insert(
             crate::config::LifeCyclePhase::PrePush,
             vec![crate::config::HookDefinition {
-                command: "echo Pre-push hook".to_string(),
+                command: "echo Pre-push hook".into(),
                 parallel_execution_allowed: false,
             }],
         );
         hooks_map.insert(
             crate::config::LifeCyclePhase::ApplypatchMsg,
             vec![crate::config::HookDefinition {
-                command: "echo Applypatch hook".to_string(),
+                command: "echo Applypatch hook".into(),
                 parallel_execution_allowed: false,
             }],
         );
         hooks_map.insert(
             crate::config::LifeCyclePhase::PreCommit,
             vec![crate::config::HookDefinition {
-                command: "echo Pre-commit hook".to_string(),
+                command: "echo Pre-commit hook".into(),
                 parallel_execution_allowed: false,
             }],
         );
@@ -961,7 +961,7 @@ mod tests {
         hooks_map.insert(
             crate::config::LifeCyclePhase::PreCommit,
             vec![crate::config::HookDefinition {
-                command: "echo Pre-commit hook".to_string(),
+                command: "echo Pre-commit hook".into(),
                 parallel_execution_allowed: false,
             }],
         );
@@ -989,7 +989,7 @@ mod tests {
         hooks_map.insert(
             crate::config::LifeCyclePhase::PreCommit,
             vec![crate::config::HookDefinition {
-                command: "echo Pre-commit hook".to_string(),
+                command: "echo Pre-commit hook".into(),
                 parallel_execution_allowed: false,
             }],
         );

--- a/crates/git-smee-core/src/installer.rs
+++ b/crates/git-smee-core/src/installer.rs
@@ -555,7 +555,7 @@ fn is_managed_file(path: &Path) -> Result<bool, Error> {
 /// hooks.insert(
 ///     LifeCyclePhase::PreCommit,
 ///     vec![HookDefinition {
-///         command: "echo pre-commit".to_string(),
+///         command: "echo pre-commit".into(),
 ///         parallel_execution_allowed: false,
 ///     }],
 /// );

--- a/crates/git-smee-core/tests/installer_integration.rs
+++ b/crates/git-smee-core/tests/installer_integration.rs
@@ -729,7 +729,7 @@ fn pre_commit_only_config() -> SmeeConfig {
     hooks.insert(
         git_smee_core::config::LifeCyclePhase::PreCommit,
         vec![git_smee_core::config::HookDefinition {
-            command: "echo pre-commit".to_string(),
+            command: "echo pre-commit".into(),
             parallel_execution_allowed: false,
         }],
     );


### PR DESCRIPTION
Fixes #185

## Summary
- add a typed `HookCommand` boundary for configured hook commands while keeping TOML serialization compatible
- move empty-command validation and safe shell-source/redacted display behind the command type
- update scheduler/runner APIs to carry `HookCommand` instead of raw command strings

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features`

## Notes
This is intended as a behavior-preserving architectural slice for the hook command execution boundary.
