### PR TITLE
refactor(core): split installer boundaries

### DIFF
--- a/crates/git-smee-core/src/installer.rs
+++ b/crates/git-smee-core/src/installer.rs
@@ -1,52 +1,20 @@
-use crate::{DEFAULT_CONFIG_FILE_NAME, SmeeConfig, config::LifeCyclePhase, platform::Platform};
-use std::{
-    fs,
-    io::{Read, Write},
-    path::{Path, PathBuf},
-};
+use crate::{SmeeConfig, platform::Platform};
+use std::path::PathBuf;
 use thiserror::Error;
 
-/// Marker string used to identify files managed by git-smee.
-pub const MANAGED_FILE_MARKER: &str = "THIS FILE IS MANAGED BY git-smee";
-const MANAGED_FILE_SCAN_BYTES: usize = 8 * 1024;
-const MANAGED_FILE_SCAN_LINES: usize = 32;
+mod filesystem;
+mod managed_file;
+mod script;
 
-/// Prefixes content with a managed marker using `#` comments.
-///
-/// If content starts with a shebang (`#!`), the marker is inserted after the shebang
-/// so script executability is preserved.
-pub fn with_managed_header(content: &str) -> String {
-    with_managed_header_with_prefix(content, "#")
-        .expect("default managed header prefix should always be supported")
-}
+pub use filesystem::{FileSystemHookInstaller, write_config_file};
+pub use managed_file::{
+    MANAGED_FILE_MARKER, has_managed_header, with_managed_header, with_managed_header_with_prefix,
+};
+pub use script::HookScriptOptions;
 
-/// Prefixes content with a managed marker using the provided comment prefix.
-///
-/// If content starts with a shebang (`#!`), the marker is inserted after the shebang
-/// so script executability is preserved.
-///
-/// Supported prefixes are `#` (Unix-style) and `REM` (Windows batch).
-pub fn with_managed_header_with_prefix(
-    content: &str,
-    comment_prefix: &str,
-) -> Result<String, Error> {
-    if !matches!(comment_prefix, "#" | "REM") {
-        return Err(Error::UnsupportedManagedHeaderPrefix {
-            prefix: comment_prefix.to_string(),
-        });
-    }
-    let marker_line = format!("{comment_prefix} {MANAGED_FILE_MARKER}");
-    if content.starts_with("#!") {
-        if let Some(shebang_end) = content.find('\n') {
-            let (shebang, rest) = content.split_at(shebang_end + 1);
-            return Ok(format!("{shebang}{marker_line}\n\n{rest}"));
-        }
-
-        return Ok(format!("{content}\n{marker_line}\n\n"));
-    }
-
-    Ok(format!("{marker_line}\n\n{content}"))
-}
+use script::render_hook_script;
+#[cfg(test)]
+use script::shell_single_quote;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -140,398 +108,6 @@ pub trait HookInstaller {
     }
 }
 
-pub struct FileSystemHookInstaller {
-    repository_root: PathBuf,
-    hooks_dir: PathBuf,
-    force_overwrite: bool,
-}
-
-#[derive(Debug, Clone)]
-pub struct HookScriptOptions {
-    pub git_smee_executable: PathBuf,
-    pub config_path: PathBuf,
-}
-
-impl HookScriptOptions {
-    pub fn new(git_smee_executable: PathBuf, config_path: PathBuf) -> Self {
-        Self {
-            git_smee_executable,
-            config_path,
-        }
-    }
-
-    fn default_for_runtime() -> Result<Self, Error> {
-        Ok(Self {
-            git_smee_executable: std::env::current_exe()
-                .map_err(Error::FailedToResolveCurrentExecutable)?,
-            config_path: PathBuf::from(DEFAULT_CONFIG_FILE_NAME),
-        })
-    }
-}
-
-impl FileSystemHookInstaller {
-    /// Git path key used to resolve the effective hooks directory.
-    pub const HOOKS_GIT_PATH_KEY: &str = "hooks";
-
-    /// Creates a hook installer rooted at the current working directory.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use git_smee_core::installer::FileSystemHookInstaller;
-    /// use std::{env, process::Command};
-    /// use tempfile::tempdir;
-    ///
-    /// let temp_dir = tempdir().unwrap();
-    /// Command::new("git")
-    ///     .arg("init")
-    ///     .current_dir(temp_dir.path())
-    ///     .output()
-    ///     .unwrap();
-    ///
-    /// let original_dir = env::current_dir().unwrap();
-    /// env::set_current_dir(temp_dir.path()).unwrap();
-    ///
-    /// let installer = FileSystemHookInstaller::new().unwrap();
-    ///
-    /// env::set_current_dir(&original_dir).unwrap();
-    /// assert!(installer.effective_hooks_dir().exists());
-    /// drop(installer);
-    /// ```
-    pub fn new() -> Result<Self, Error> {
-        Self::from_default()
-    }
-
-    /// Creates a hook installer using `./` as the repository root.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use git_smee_core::installer::FileSystemHookInstaller;
-    /// use std::{env, process::Command};
-    /// use tempfile::tempdir;
-    ///
-    /// let temp_dir = tempdir().unwrap();
-    /// Command::new("git")
-    ///     .arg("init")
-    ///     .current_dir(temp_dir.path())
-    ///     .output()
-    ///     .unwrap();
-    ///
-    /// let original_dir = env::current_dir().unwrap();
-    /// env::set_current_dir(temp_dir.path()).unwrap();
-    ///
-    /// let installer = FileSystemHookInstaller::from_default().unwrap();
-    ///
-    /// env::set_current_dir(&original_dir).unwrap();
-    /// assert!(installer.effective_hooks_dir().exists());
-    /// drop(installer);
-    /// ```
-    pub fn from_default() -> Result<Self, Error> {
-        Self::from_default_with_force(false)
-    }
-
-    /// Creates a hook installer using `./` as the repository root and a
-    /// configurable overwrite policy.
-    pub fn from_default_with_force(force_overwrite: bool) -> Result<Self, Error> {
-        Self::from_path_with_force(PathBuf::from("./"), force_overwrite)
-    }
-
-    /// Creates a `FileSystemHookInstaller` rooted at the provided repository path.
-    ///
-    /// The hooks directory must exist within the provided root.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use git_smee_core::installer::FileSystemHookInstaller;
-    /// use std::process::Command;
-    /// use tempfile::tempdir;
-    ///
-    /// let temp_dir = tempdir().unwrap();
-    /// Command::new("git")
-    ///     .arg("init")
-    ///     .current_dir(temp_dir.path())
-    ///     .output()
-    ///     .unwrap();
-    ///
-    /// let installer = FileSystemHookInstaller::from_path(temp_dir.path().to_path_buf()).unwrap();
-    /// assert!(installer.effective_hooks_dir().exists());
-    /// drop(installer);
-    /// ```
-    pub fn from_path(repository_root: PathBuf) -> Result<Self, Error> {
-        Self::from_path_with_force(repository_root, false)
-    }
-
-    /// Creates a `FileSystemHookInstaller` rooted at the provided repository path and
-    /// with explicit overwrite behavior.
-    pub fn from_path_with_force(
-        repository_root: PathBuf,
-        force_overwrite: bool,
-    ) -> Result<Self, Error> {
-        let repository_root =
-            repository_root
-                .canonicalize()
-                .map_err(|source| Error::InvalidRepositoryRoot {
-                    path: repository_root.to_string_lossy().to_string(),
-                    source,
-                })?;
-        let hooks_path =
-            crate::repository::resolve_git_path(&repository_root, Self::HOOKS_GIT_PATH_KEY)?;
-        if !hooks_path.exists() {
-            fs::create_dir_all(&hooks_path).map_err(|source| Error::FailedToCreateHooksDir {
-                path: hooks_path.to_string_lossy().to_string(),
-                source,
-            })?;
-        }
-        if !hooks_path.is_dir() {
-            return Err(Error::HooksDirNotFound(
-                hooks_path.to_string_lossy().to_string(),
-            ));
-        }
-        Ok(Self {
-            repository_root,
-            hooks_dir: hooks_path,
-            force_overwrite,
-        })
-    }
-
-    pub fn effective_hooks_dir(&self) -> &PathBuf {
-        &self.hooks_dir
-    }
-
-    pub fn ensure_can_write_managed_config(
-        config_file: &Path,
-        force_overwrite: bool,
-    ) -> Result<(), Error> {
-        ensure_not_symlink(config_file)?;
-
-        if !config_file.exists() || force_overwrite {
-            return Ok(());
-        }
-
-        let path = config_file.to_string_lossy().to_string();
-        if is_managed_file(config_file)? {
-            return Err(Error::RefusingToOverwriteManagedConfigFile { path });
-        }
-
-        Err(Error::RefusingToOverwriteUnmanagedConfigFile { path })
-    }
-
-    fn ensure_can_write_hook(&self, hook_file: &Path) -> Result<(), Error> {
-        ensure_not_symlink(hook_file)?;
-
-        if !hook_file.exists() || self.force_overwrite {
-            return Ok(());
-        }
-
-        if is_managed_file(hook_file)? {
-            return Ok(());
-        }
-
-        Err(Error::RefusingToOverwriteUnmanagedHookFile {
-            path: hook_file.to_string_lossy().to_string(),
-        })
-    }
-
-    fn ensure_can_write_config(&self, config_file: &Path) -> Result<(), Error> {
-        ensure_can_write_config_file(config_file, self.force_overwrite)
-    }
-
-    fn prune_obsolete_managed_hook(
-        &self,
-        hook_name: &str,
-        active_hook_names: &[String],
-    ) -> Result<(), Error> {
-        if active_hook_names
-            .iter()
-            .any(|active_hook| active_hook == hook_name)
-        {
-            return Ok(());
-        }
-
-        let hook_file = self.hooks_dir.join(hook_name);
-        if !hook_file.exists() || !is_managed_file(&hook_file)? {
-            return Ok(());
-        }
-
-        fs::remove_file(&hook_file).map_err(|source| Error::FailedToRemoveObsoleteHook {
-            path: hook_file.to_string_lossy().to_string(),
-            source,
-        })
-    }
-}
-
-impl HookInstaller for FileSystemHookInstaller {
-    fn prepare_install_hooks(&self, hook_names: &[String]) -> Result<(), Error> {
-        for hook_name in hook_names {
-            let hook_file = self.hooks_dir.join(hook_name);
-            self.ensure_can_write_hook(&hook_file)?;
-        }
-        Ok(())
-    }
-
-    fn install_hook(&self, hook_name: &str, hook_content: &str) -> Result<PathBuf, Error> {
-        let hook_file = self.hooks_dir.join(hook_name);
-        self.ensure_can_write_hook(&hook_file)?;
-        atomic_write_file(&hook_file, hook_content).map_err(|source| Error::FailedToWriteHook {
-            path: hook_file.to_string_lossy().to_string(),
-            source,
-        })?;
-        Ok(hook_file)
-    }
-
-    fn install_config_file(&self, config_content: &str) -> Result<PathBuf, Error> {
-        let config_path = self.repository_root.join(DEFAULT_CONFIG_FILE_NAME);
-        self.ensure_can_write_config(&config_path)?;
-        atomic_write_file(&config_path, config_content).map_err(|source| {
-            Error::FailedToWriteConfigFile {
-                path: config_path.to_string_lossy().to_string(),
-                source,
-            }
-        })?;
-        Ok(config_path)
-    }
-
-    fn prune_obsolete_hooks(&self, active_hook_names: &[String]) -> Result<(), Error> {
-        for phase in LifeCyclePhase::all() {
-            self.prune_obsolete_managed_hook(phase.as_str(), active_hook_names)?;
-        }
-        Ok(())
-    }
-}
-
-/// Writes a git-smee config file at an arbitrary path using the same managed/unmanaged
-/// overwrite semantics as [`FileSystemHookInstaller::install_config_file`].
-pub fn write_config_file(
-    config_path: &Path,
-    config_content: &str,
-    force_overwrite: bool,
-) -> Result<(), Error> {
-    ensure_can_write_config_file(config_path, force_overwrite)?;
-    if let Some(parent) = config_path.parent()
-        && !parent.as_os_str().is_empty()
-    {
-        fs::create_dir_all(parent).map_err(|source| Error::FailedToWriteConfigFile {
-            path: config_path.to_string_lossy().to_string(),
-            source,
-        })?;
-    }
-    atomic_write_file(config_path, config_content).map_err(|source| {
-        Error::FailedToWriteConfigFile {
-            path: config_path.to_string_lossy().to_string(),
-            source,
-        }
-    })
-}
-
-fn atomic_write_file(path: &Path, content: &str) -> std::io::Result<()> {
-    let parent = path
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."));
-    let mut temp_file = tempfile::Builder::new()
-        .prefix(".git-smee-")
-        .suffix(".tmp")
-        .tempfile_in(parent)?;
-
-    temp_file.write_all(content.as_bytes())?;
-    temp_file.flush()?;
-    temp_file.as_file().sync_all()?;
-    temp_file.persist(path).map_err(|error| error.error)?;
-    sync_parent_dir(parent)?;
-    Ok(())
-}
-
-#[cfg(unix)]
-fn sync_parent_dir(parent: &Path) -> std::io::Result<()> {
-    fs::File::open(parent)?.sync_all()
-}
-
-#[cfg(not(unix))]
-fn sync_parent_dir(_parent: &Path) -> std::io::Result<()> {
-    Ok(())
-}
-
-fn ensure_can_write_config_file(config_file: &Path, force_overwrite: bool) -> Result<(), Error> {
-    ensure_not_symlink(config_file)?;
-
-    if config_file.exists() && !config_file.is_file() {
-        return Err(Error::ConfigPathNotAFile {
-            path: config_file.to_string_lossy().to_string(),
-        });
-    }
-
-    if !config_file.exists() || force_overwrite {
-        return Ok(());
-    }
-
-    let path = config_file.to_string_lossy().to_string();
-    if is_managed_file(config_file)? {
-        return Err(Error::RefusingToOverwriteManagedConfigFile { path });
-    }
-
-    Err(Error::RefusingToOverwriteUnmanagedConfigFile { path })
-}
-
-fn ensure_not_symlink(path: &Path) -> Result<(), Error> {
-    match fs::symlink_metadata(path) {
-        Ok(metadata) if metadata.file_type().is_symlink() => Err(Error::RefusingToWriteSymlink {
-            path: path.to_string_lossy().to_string(),
-        }),
-        Ok(_) => Ok(()),
-        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(source) => Err(Error::FailedToReadExistingFile {
-            path: path.to_string_lossy().to_string(),
-            source,
-        }),
-    }
-}
-
-/// Returns true when a file has git-smee's managed marker in its header.
-///
-/// The marker must appear in the same header position accepted by installer
-/// overwrite/pruning logic; marker text later in a hook body is treated as
-/// user-owned content.
-pub fn has_managed_header(path: &Path) -> Result<bool, Error> {
-    is_managed_file(path)
-}
-
-fn is_managed_file(path: &Path) -> Result<bool, Error> {
-    let mut file = fs::File::open(path).map_err(|source| Error::FailedToReadExistingFile {
-        path: path.to_string_lossy().to_string(),
-        source,
-    })?;
-    let mut header_buf = [0_u8; MANAGED_FILE_SCAN_BYTES];
-    let bytes_read =
-        file.read(&mut header_buf)
-            .map_err(|source| Error::FailedToReadExistingFile {
-                path: path.to_string_lossy().to_string(),
-                source,
-            })?;
-    let header = &header_buf[..bytes_read];
-    let marker_hash = format!("# {MANAGED_FILE_MARKER}");
-    let marker_rem = format!("REM {MANAGED_FILE_MARKER}");
-
-    for line in header
-        .split(|byte| *byte == b'\n')
-        .take(MANAGED_FILE_SCAN_LINES)
-    {
-        let normalized_line = line.strip_prefix(&[0xEF, 0xBB, 0xBF]).unwrap_or(line);
-        let normalized_line = normalized_line
-            .strip_suffix(b"\r")
-            .unwrap_or(normalized_line);
-        if normalized_line.is_empty() {
-            continue;
-        }
-        if normalized_line == marker_hash.as_bytes() || normalized_line == marker_rem.as_bytes() {
-            return Ok(true);
-        }
-    }
-
-    Ok(false)
-}
-
 /// Installs hook scripts for each configured lifecycle phase.
 ///
 /// # Examples
@@ -583,8 +159,6 @@ pub fn install_hooks_with_options<T: HookInstaller>(
         return Err(Error::NoHooksPresent);
     }
     let platform = Platform::current();
-    let escaped_executable = shell_single_quote(&options.git_smee_executable);
-    let escaped_config_path = shell_single_quote(&options.config_path);
     let mut phases: Vec<_> = config.hooks.keys().copied().collect();
     phases.sort_by_key(|phase| phase.as_str());
     let active_hook_names: Vec<_> = phases.iter().map(|phase| phase.to_string()).collect();
@@ -593,12 +167,7 @@ pub fn install_hooks_with_options<T: HookInstaller>(
         .into_iter()
         .map(|life_cycle_phase| {
             let lifecycle_phase_kebap = life_cycle_phase.to_string();
-            let content = platform
-                .hook_script_template()
-                .replace("{hook}", &lifecycle_phase_kebap);
-            let content = content
-                .replace("{git_smee_executable}", &escaped_executable)
-                .replace("{config_path}", &escaped_config_path);
+            let content = render_hook_script(&platform, &lifecycle_phase_kebap, options);
             let hook_path = hook_installer.install_hook(&lifecycle_phase_kebap, &content)?;
             platform
                 .make_executable(&hook_path)
@@ -610,39 +179,14 @@ pub fn install_hooks_with_options<T: HookInstaller>(
     Ok(())
 }
 
-fn shell_single_quote(path: &Path) -> String {
-    unix_shell_path_word(path)
-}
-
-#[cfg(unix)]
-fn unix_shell_path_word(path: &Path) -> String {
-    use std::os::unix::ffi::OsStrExt;
-
-    match path.as_os_str().to_str() {
-        Some(path) => format!("'{}'", path.replace('\'', "'\"'\"'")),
-        None => {
-            let escaped = path
-                .as_os_str()
-                .as_bytes()
-                .iter()
-                .map(|byte| format!(r"\{byte:03o}"))
-                .collect::<String>();
-            format!(r#"$(printf '%b' '{escaped}')"#)
-        }
-    }
-}
-
-#[cfg(not(unix))]
-fn unix_shell_path_word(path: &Path) -> String {
-    format!("'{}'", path.to_string_lossy().replace('\'', "'\"'\"'"))
-}
-
 #[cfg(test)]
 mod tests {
+    use crate::DEFAULT_CONFIG_FILE_NAME;
     use std::sync::{
         Mutex,
         atomic::{AtomicU8, Ordering},
     };
+    use std::{fs, path::Path};
 
     use super::*;
 

--- a/crates/git-smee-core/src/installer/filesystem.rs
+++ b/crates/git-smee-core/src/installer/filesystem.rs
@@ -1,0 +1,256 @@
+use std::{
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+use crate::{DEFAULT_CONFIG_FILE_NAME, config::LifeCyclePhase};
+
+use super::managed_file::{ensure_can_write_config_file, ensure_not_symlink, is_managed_file};
+use super::{Error, HookInstaller};
+
+pub struct FileSystemHookInstaller {
+    repository_root: PathBuf,
+    hooks_dir: PathBuf,
+    force_overwrite: bool,
+}
+
+impl FileSystemHookInstaller {
+    /// Git path key used to resolve the effective hooks directory.
+    pub const HOOKS_GIT_PATH_KEY: &str = "hooks";
+
+    /// Creates a hook installer rooted at the current working directory.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use git_smee_core::installer::FileSystemHookInstaller;
+    /// use std::{env, process::Command};
+    /// use tempfile::tempdir;
+    ///
+    /// let temp_dir = tempdir().unwrap();
+    /// Command::new("git")
+    ///     .arg("init")
+    ///     .current_dir(temp_dir.path())
+    ///     .output()
+    ///     .unwrap();
+    ///
+    /// let original_dir = env::current_dir().unwrap();
+    /// env::set_current_dir(temp_dir.path()).unwrap();
+    ///
+    /// let installer = FileSystemHookInstaller::new().unwrap();
+    ///
+    /// env::set_current_dir(&original_dir).unwrap();
+    /// assert!(installer.effective_hooks_dir().exists());
+    /// drop(installer);
+    /// ```
+    pub fn new() -> Result<Self, Error> {
+        Self::from_default()
+    }
+
+    /// Creates a hook installer using `./` as the repository root.
+    pub fn from_default() -> Result<Self, Error> {
+        Self::from_default_with_force(false)
+    }
+
+    /// Creates a hook installer using `./` as the repository root and a
+    /// configurable overwrite policy.
+    pub fn from_default_with_force(force_overwrite: bool) -> Result<Self, Error> {
+        Self::from_path_with_force(PathBuf::from("./"), force_overwrite)
+    }
+
+    /// Creates a `FileSystemHookInstaller` rooted at the provided repository path.
+    pub fn from_path(repository_root: PathBuf) -> Result<Self, Error> {
+        Self::from_path_with_force(repository_root, false)
+    }
+
+    /// Creates a `FileSystemHookInstaller` rooted at the provided repository path and
+    /// with explicit overwrite behavior.
+    pub fn from_path_with_force(
+        repository_root: PathBuf,
+        force_overwrite: bool,
+    ) -> Result<Self, Error> {
+        let repository_root =
+            repository_root
+                .canonicalize()
+                .map_err(|source| Error::InvalidRepositoryRoot {
+                    path: repository_root.to_string_lossy().to_string(),
+                    source,
+                })?;
+        let hooks_path =
+            crate::repository::resolve_git_path(&repository_root, Self::HOOKS_GIT_PATH_KEY)?;
+        if !hooks_path.exists() {
+            fs::create_dir_all(&hooks_path).map_err(|source| Error::FailedToCreateHooksDir {
+                path: hooks_path.to_string_lossy().to_string(),
+                source,
+            })?;
+        }
+        if !hooks_path.is_dir() {
+            return Err(Error::HooksDirNotFound(
+                hooks_path.to_string_lossy().to_string(),
+            ));
+        }
+        Ok(Self {
+            repository_root,
+            hooks_dir: hooks_path,
+            force_overwrite,
+        })
+    }
+
+    pub fn effective_hooks_dir(&self) -> &PathBuf {
+        &self.hooks_dir
+    }
+
+    pub fn ensure_can_write_managed_config(
+        config_file: &Path,
+        force_overwrite: bool,
+    ) -> Result<(), Error> {
+        ensure_not_symlink(config_file)?;
+
+        if !config_file.exists() || force_overwrite {
+            return Ok(());
+        }
+
+        let path = config_file.to_string_lossy().to_string();
+        if is_managed_file(config_file)? {
+            return Err(Error::RefusingToOverwriteManagedConfigFile { path });
+        }
+
+        Err(Error::RefusingToOverwriteUnmanagedConfigFile { path })
+    }
+
+    fn ensure_can_write_hook(&self, hook_file: &Path) -> Result<(), Error> {
+        ensure_not_symlink(hook_file)?;
+
+        if !hook_file.exists() || self.force_overwrite {
+            return Ok(());
+        }
+
+        if is_managed_file(hook_file)? {
+            return Ok(());
+        }
+
+        Err(Error::RefusingToOverwriteUnmanagedHookFile {
+            path: hook_file.to_string_lossy().to_string(),
+        })
+    }
+
+    fn ensure_can_write_config(&self, config_file: &Path) -> Result<(), Error> {
+        ensure_can_write_config_file(config_file, self.force_overwrite)
+    }
+
+    fn prune_obsolete_managed_hook(
+        &self,
+        hook_name: &str,
+        active_hook_names: &[String],
+    ) -> Result<(), Error> {
+        if active_hook_names
+            .iter()
+            .any(|active_hook| active_hook == hook_name)
+        {
+            return Ok(());
+        }
+
+        let hook_file = self.hooks_dir.join(hook_name);
+        if !hook_file.exists() || !is_managed_file(&hook_file)? {
+            return Ok(());
+        }
+
+        fs::remove_file(&hook_file).map_err(|source| Error::FailedToRemoveObsoleteHook {
+            path: hook_file.to_string_lossy().to_string(),
+            source,
+        })
+    }
+}
+
+impl HookInstaller for FileSystemHookInstaller {
+    fn prepare_install_hooks(&self, hook_names: &[String]) -> Result<(), Error> {
+        for hook_name in hook_names {
+            let hook_file = self.hooks_dir.join(hook_name);
+            self.ensure_can_write_hook(&hook_file)?;
+        }
+        Ok(())
+    }
+
+    fn install_hook(&self, hook_name: &str, hook_content: &str) -> Result<PathBuf, Error> {
+        let hook_file = self.hooks_dir.join(hook_name);
+        self.ensure_can_write_hook(&hook_file)?;
+        atomic_write_file(&hook_file, hook_content).map_err(|source| Error::FailedToWriteHook {
+            path: hook_file.to_string_lossy().to_string(),
+            source,
+        })?;
+        Ok(hook_file)
+    }
+
+    fn install_config_file(&self, config_content: &str) -> Result<PathBuf, Error> {
+        let config_path = self.repository_root.join(DEFAULT_CONFIG_FILE_NAME);
+        self.ensure_can_write_config(&config_path)?;
+        atomic_write_file(&config_path, config_content).map_err(|source| {
+            Error::FailedToWriteConfigFile {
+                path: config_path.to_string_lossy().to_string(),
+                source,
+            }
+        })?;
+        Ok(config_path)
+    }
+
+    fn prune_obsolete_hooks(&self, active_hook_names: &[String]) -> Result<(), Error> {
+        for phase in LifeCyclePhase::all() {
+            self.prune_obsolete_managed_hook(phase.as_str(), active_hook_names)?;
+        }
+        Ok(())
+    }
+}
+
+/// Writes a git-smee config file at an arbitrary path using the same managed/unmanaged
+/// overwrite semantics as [`FileSystemHookInstaller::install_config_file`].
+pub fn write_config_file(
+    config_path: &Path,
+    config_content: &str,
+    force_overwrite: bool,
+) -> Result<(), Error> {
+    ensure_can_write_config_file(config_path, force_overwrite)?;
+    match config_path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => {
+            fs::create_dir_all(parent).map_err(|source| Error::FailedToWriteConfigFile {
+                path: config_path.to_string_lossy().to_string(),
+                source,
+            })?;
+        }
+        _ => {}
+    }
+    atomic_write_file(config_path, config_content).map_err(|source| {
+        Error::FailedToWriteConfigFile {
+            path: config_path.to_string_lossy().to_string(),
+            source,
+        }
+    })
+}
+
+fn atomic_write_file(path: &Path, content: &str) -> std::io::Result<()> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let mut temp_file = tempfile::Builder::new()
+        .prefix(".git-smee-")
+        .suffix(".tmp")
+        .tempfile_in(parent)?;
+
+    temp_file.write_all(content.as_bytes())?;
+    temp_file.flush()?;
+    temp_file.as_file().sync_all()?;
+    temp_file.persist(path).map_err(|error| error.error)?;
+    sync_parent_dir(parent)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn sync_parent_dir(parent: &Path) -> std::io::Result<()> {
+    fs::File::open(parent)?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_parent_dir(_parent: &Path) -> std::io::Result<()> {
+    Ok(())
+}

--- a/crates/git-smee-core/src/installer/managed_file.rs
+++ b/crates/git-smee-core/src/installer/managed_file.rs
@@ -1,0 +1,127 @@
+use std::{fs, io::Read, path::Path};
+
+use super::Error;
+
+/// Marker string used to identify files managed by git-smee.
+pub const MANAGED_FILE_MARKER: &str = "THIS FILE IS MANAGED BY git-smee";
+const MANAGED_FILE_SCAN_BYTES: usize = 8 * 1024;
+const MANAGED_FILE_SCAN_LINES: usize = 32;
+
+/// Prefixes content with a managed marker using `#` comments.
+///
+/// If content starts with a shebang (`#!`), the marker is inserted after the shebang
+/// so script executability is preserved.
+pub fn with_managed_header(content: &str) -> String {
+    with_managed_header_with_prefix(content, "#")
+        .expect("default managed header prefix should always be supported")
+}
+
+/// Prefixes content with a managed marker using the provided comment prefix.
+///
+/// If content starts with a shebang (`#!`), the marker is inserted after the shebang
+/// so script executability is preserved.
+///
+/// Supported prefixes are `#` (Unix-style) and `REM` (Windows batch).
+pub fn with_managed_header_with_prefix(
+    content: &str,
+    comment_prefix: &str,
+) -> Result<String, Error> {
+    if !matches!(comment_prefix, "#" | "REM") {
+        return Err(Error::UnsupportedManagedHeaderPrefix {
+            prefix: comment_prefix.to_string(),
+        });
+    }
+    let marker_line = format!("{comment_prefix} {MANAGED_FILE_MARKER}");
+    if content.starts_with("#!") {
+        if let Some(shebang_end) = content.find('\n') {
+            let (shebang, rest) = content.split_at(shebang_end + 1);
+            return Ok(format!("{shebang}{marker_line}\n\n{rest}"));
+        }
+
+        return Ok(format!("{content}\n{marker_line}\n\n"));
+    }
+
+    Ok(format!("{marker_line}\n\n{content}"))
+}
+
+pub(crate) fn ensure_can_write_config_file(
+    config_file: &Path,
+    force_overwrite: bool,
+) -> Result<(), Error> {
+    ensure_not_symlink(config_file)?;
+
+    if config_file.exists() && !config_file.is_file() {
+        return Err(Error::ConfigPathNotAFile {
+            path: config_file.to_string_lossy().to_string(),
+        });
+    }
+
+    if !config_file.exists() || force_overwrite {
+        return Ok(());
+    }
+
+    let path = config_file.to_string_lossy().to_string();
+    if is_managed_file(config_file)? {
+        return Err(Error::RefusingToOverwriteManagedConfigFile { path });
+    }
+
+    Err(Error::RefusingToOverwriteUnmanagedConfigFile { path })
+}
+
+pub(crate) fn ensure_not_symlink(path: &Path) -> Result<(), Error> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(Error::RefusingToWriteSymlink {
+            path: path.to_string_lossy().to_string(),
+        }),
+        Ok(_) => Ok(()),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(Error::FailedToReadExistingFile {
+            path: path.to_string_lossy().to_string(),
+            source,
+        }),
+    }
+}
+
+/// Returns true when a file has git-smee's managed marker in its header.
+///
+/// The marker must appear in the same header position accepted by installer
+/// overwrite/pruning logic; marker text later in a hook body is treated as
+/// user-owned content.
+pub fn has_managed_header(path: &Path) -> Result<bool, Error> {
+    is_managed_file(path)
+}
+
+pub(crate) fn is_managed_file(path: &Path) -> Result<bool, Error> {
+    let mut file = fs::File::open(path).map_err(|source| Error::FailedToReadExistingFile {
+        path: path.to_string_lossy().to_string(),
+        source,
+    })?;
+    let mut header_buf = [0_u8; MANAGED_FILE_SCAN_BYTES];
+    let bytes_read =
+        file.read(&mut header_buf)
+            .map_err(|source| Error::FailedToReadExistingFile {
+                path: path.to_string_lossy().to_string(),
+                source,
+            })?;
+    let header = &header_buf[..bytes_read];
+    let marker_hash = format!("# {MANAGED_FILE_MARKER}");
+    let marker_rem = format!("REM {MANAGED_FILE_MARKER}");
+
+    for line in header
+        .split(|byte| *byte == b'\n')
+        .take(MANAGED_FILE_SCAN_LINES)
+    {
+        let normalized_line = line.strip_prefix(&[0xEF, 0xBB, 0xBF]).unwrap_or(line);
+        let normalized_line = normalized_line
+            .strip_suffix(b"\r")
+            .unwrap_or(normalized_line);
+        if normalized_line.is_empty() {
+            continue;
+        }
+        if normalized_line == marker_hash.as_bytes() || normalized_line == marker_rem.as_bytes() {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}

--- a/crates/git-smee-core/src/installer/script.rs
+++ b/crates/git-smee-core/src/installer/script.rs
@@ -1,0 +1,69 @@
+use std::path::{Path, PathBuf};
+
+use crate::{DEFAULT_CONFIG_FILE_NAME, platform::Platform};
+
+use super::Error;
+
+#[derive(Debug, Clone)]
+pub struct HookScriptOptions {
+    pub git_smee_executable: PathBuf,
+    pub config_path: PathBuf,
+}
+
+impl HookScriptOptions {
+    pub fn new(git_smee_executable: PathBuf, config_path: PathBuf) -> Self {
+        Self {
+            git_smee_executable,
+            config_path,
+        }
+    }
+
+    pub(crate) fn default_for_runtime() -> Result<Self, Error> {
+        Ok(Self {
+            git_smee_executable: std::env::current_exe()
+                .map_err(Error::FailedToResolveCurrentExecutable)?,
+            config_path: PathBuf::from(DEFAULT_CONFIG_FILE_NAME),
+        })
+    }
+}
+
+pub(crate) fn render_hook_script(
+    platform: &Platform,
+    hook_name: &str,
+    options: &HookScriptOptions,
+) -> String {
+    let escaped_executable = shell_single_quote(&options.git_smee_executable);
+    let escaped_config_path = shell_single_quote(&options.config_path);
+    platform
+        .hook_script_template()
+        .replace("{hook}", hook_name)
+        .replace("{git_smee_executable}", &escaped_executable)
+        .replace("{config_path}", &escaped_config_path)
+}
+
+pub(crate) fn shell_single_quote(path: &Path) -> String {
+    unix_shell_path_word(path)
+}
+
+#[cfg(unix)]
+fn unix_shell_path_word(path: &Path) -> String {
+    use std::os::unix::ffi::OsStrExt;
+
+    match path.as_os_str().to_str() {
+        Some(path) => format!("'{}'", path.replace('\'', "'\"'\"'")),
+        None => {
+            let escaped = path
+                .as_os_str()
+                .as_bytes()
+                .iter()
+                .map(|byte| format!(r"\{byte:03o}"))
+                .collect::<String>();
+            format!(r#"$(printf '%b' '{escaped}')"#)
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn unix_shell_path_word(path: &Path) -> String {
+    format!("'{}'", path.to_string_lossy().replace('\'', "'\"'\"'"))
+}


### PR DESCRIPTION
Refs #187

## Summary
- split installer filesystem side effects into `installer::filesystem`
- move managed marker/header and overwrite classification helpers into `installer::managed_file`
- isolate hook script option/rendering and path quoting in `installer::script`
- keep the public installer facade/re-exports stable for existing callers

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`
