### PR TITLE
Enforce HookCommand's non-empty invariant

### DIFF
--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -759,7 +759,7 @@ fn given_directory_config_when_install_then_user_friendly_not_a_file_error() {
 }
 
 #[test]
-fn given_invalid_config_when_install_then_validation_error_is_reported() {
+fn given_invalid_config_when_install_then_parse_error_keeps_hook_and_entry_context() {
     let test_repo = common::TestRepo::default();
     test_repo.write_config(
         r#"
@@ -778,7 +778,7 @@ command = "   "
         .failure()
         .stderr(
             predicate::str::contains(
-                "Error: Hook 'pre-commit' entry #2: command must not be empty",
+                "Error: Failed to parse the configuration file: Hook 'pre-commit' entry #2: command must not be empty",
             )
             .and(predicate::str::contains("EmptyCommand").not()),
         );

--- a/crates/git-smee-core/src/config.rs
+++ b/crates/git-smee-core/src/config.rs
@@ -197,7 +197,11 @@ impl TryFrom<&str> for HookCommand {
     type Error = HookCommandError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        Self::try_from(value.to_string())
+        if value.trim().is_empty() {
+            Err(HookCommandError)
+        } else {
+            Self::try_from(value.to_string())
+        }
     }
 }
 

--- a/crates/git-smee-core/src/config.rs
+++ b/crates/git-smee-core/src/config.rs
@@ -7,13 +7,60 @@ use std::{
     str::FromStr,
 };
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de};
 use thiserror::Error;
 
-#[derive(Deserialize, Serialize)]
+#[derive(Serialize)]
 pub struct SmeeConfig {
     #[serde(flatten)]
     pub hooks: HashMap<LifeCyclePhase, Vec<HookDefinition>>,
+}
+
+#[derive(Deserialize)]
+struct SmeeConfigWire {
+    #[serde(flatten)]
+    hooks: HashMap<LifeCyclePhase, Vec<HookDefinitionWire>>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct HookDefinitionWire {
+    command: String,
+    #[serde(default = "bool::default")]
+    parallel_execution_allowed: bool,
+}
+
+impl<'de> Deserialize<'de> for SmeeConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = SmeeConfigWire::deserialize(deserializer)?;
+        let hooks = wire
+            .hooks
+            .into_iter()
+            .map(|(phase, definitions)| {
+                let definitions = definitions
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, definition)| {
+                        let command = HookCommand::try_from(definition.command).map_err(|_| {
+                            de::Error::custom(ValidationError::EmptyCommand {
+                                hook_name: phase.to_string(),
+                                entry_index: index + 1,
+                            })
+                        })?;
+                        Ok(HookDefinition {
+                            command,
+                            parallel_execution_allowed: definition.parallel_execution_allowed,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, D::Error>>()?;
+                Ok((phase, definitions))
+            })
+            .collect::<Result<HashMap<_, _>, D::Error>>()?;
+        Ok(Self { hooks })
+    }
 }
 
 impl SmeeConfig {
@@ -73,15 +120,6 @@ impl SmeeConfig {
                     hook_name: phase.to_string(),
                 });
             }
-
-            for (index, hook_definition) in hooks.iter().enumerate() {
-                if hook_definition.command.is_empty() {
-                    return Err(ValidationError::EmptyCommand {
-                        hook_name: phase.to_string(),
-                        entry_index: index + 1,
-                    });
-                }
-            }
         }
 
         Ok(())
@@ -94,7 +132,8 @@ impl Default for SmeeConfig {
         hash_map.insert(
             LifeCyclePhase::PreCommit,
             vec![HookDefinition {
-                command: "echo 'Default pre-commit hook'".into(),
+                command: HookCommand::try_from("echo 'Default pre-commit hook'")
+                    .expect("default hook command should be valid"),
                 parallel_execution_allowed: false,
             }],
         );
@@ -126,17 +165,15 @@ pub struct HookDefinition {
     pub parallel_execution_allowed: bool,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+/// A validated, non-empty shell command configured for a Git hook.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 #[serde(transparent)]
 pub struct HookCommand(String);
 
 impl HookCommand {
+    /// Returns the exact configured shell source without trimming or normalization.
     pub fn as_shell_source(&self) -> &str {
         &self.0
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.0.trim().is_empty()
     }
 
     pub(crate) fn redacted(&self) -> String {
@@ -144,17 +181,40 @@ impl HookCommand {
     }
 }
 
-impl From<String> for HookCommand {
-    fn from(value: String) -> Self {
-        Self(value)
+impl TryFrom<String> for HookCommand {
+    type Error = HookCommandError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        if value.trim().is_empty() {
+            Err(HookCommandError)
+        } else {
+            Ok(Self(value))
+        }
     }
 }
 
-impl From<&str> for HookCommand {
-    fn from(value: &str) -> Self {
-        Self(value.to_string())
+impl TryFrom<&str> for HookCommand {
+    type Error = HookCommandError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::try_from(value.to_string())
     }
 }
+
+impl<'de> Deserialize<'de> for HookCommand {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let source = String::deserialize(deserializer)?;
+        Self::try_from(source).map_err(de::Error::custom)
+    }
+}
+
+/// Returned when a hook command contains only whitespace or no characters.
+#[derive(Clone, Copy, Debug, Error, Eq, PartialEq)]
+#[error("command must not be empty")]
+pub struct HookCommandError;
 
 impl PartialEq<&str> for HookCommand {
     fn eq(&self, other: &&str) -> bool {
@@ -466,7 +526,7 @@ mod tests {
     #[test]
     fn given_hook_command_when_inspecting_then_shell_source_and_redacted_display_are_owned_by_type()
     {
-        let command = HookCommand::from("TOKEN=super-secret deploy --token hidden");
+        let command = HookCommand::try_from("TOKEN=super-secret deploy --token hidden").unwrap();
 
         assert_eq!(
             command.as_shell_source(),
@@ -476,38 +536,49 @@ mod tests {
     }
 
     #[test]
-    fn given_whitespace_hook_command_when_checking_empty_then_command_type_rejects_it() {
-        let command = HookCommand::from("   ");
-
-        assert!(command.is_empty());
+    fn given_empty_or_whitespace_hook_command_when_constructing_then_command_type_rejects_it() {
+        assert!(HookCommand::try_from("").is_err());
+        assert!(HookCommand::try_from("   \t\n").is_err());
+        assert!(HookCommand::try_from(String::new()).is_err());
     }
 
     #[test]
-    fn given_empty_command_when_validating_then_error_contains_hook_and_entry() {
-        let mut hooks = HashMap::new();
-        hooks.insert(
-            LifeCyclePhase::PreCommit,
-            vec![
-                HookDefinition {
-                    command: "cargo test".into(),
-                    parallel_execution_allowed: false,
-                },
-                HookDefinition {
-                    command: "   ".into(),
-                    parallel_execution_allowed: false,
-                },
-            ],
-        );
-        let config = SmeeConfig { hooks };
+    fn given_padded_non_empty_hook_command_when_constructing_then_exact_shell_source_is_preserved()
+    {
+        let command = HookCommand::try_from("  echo preserved  ").unwrap();
 
-        let result = config.validate();
+        assert_eq!(command.as_shell_source(), "  echo preserved  ");
+    }
+
+    #[test]
+    fn given_empty_or_whitespace_hook_command_when_deserializing_then_it_is_rejected() {
+        for source in ["", "   \t"] {
+            let config = format!(
+                r#"
+            [[pre-commit]]
+            command = "{source}"
+            "#
+            );
+
+            assert!(toml::from_str::<SmeeConfig>(&config).is_err());
+        }
+    }
+
+    #[test]
+    fn given_padded_hook_command_when_deserializing_then_exact_shell_source_is_preserved() {
+        let config = toml::from_str::<SmeeConfig>(
+            r#"
+            [[pre-commit]]
+            command = "  echo preserved  "
+            "#,
+        )
+        .unwrap();
 
         assert_eq!(
-            result,
-            Err(ValidationError::EmptyCommand {
-                hook_name: "pre-commit".to_string(),
-                entry_index: 2,
-            })
+            config.hooks[&LifeCyclePhase::PreCommit][0]
+                .command
+                .as_shell_source(),
+            "  echo preserved  "
         );
     }
 
@@ -533,7 +604,7 @@ mod tests {
         hooks.insert(
             LifeCyclePhase::PreCommit,
             vec![HookDefinition {
-                command: "cargo test".into(),
+                command: "cargo test".try_into().unwrap(),
                 parallel_execution_allowed: false,
             }],
         );

--- a/crates/git-smee-core/src/executor.rs
+++ b/crates/git-smee-core/src/executor.rs
@@ -19,8 +19,6 @@ pub enum Error {
     ExecutionTerminatedBySignal,
     #[error("No hooks configured for lifecycle phase: {0}")]
     NoHooksConfigured(LifeCyclePhase),
-    #[error("No command defined")]
-    NoCommandDefined,
     #[error("Failed to spawn hook command '{command}' via '{shell}': {source}")]
     CommandSpawnFailed {
         command: String,
@@ -273,7 +271,7 @@ mod tests {
         hooks_map.insert(
             LifeCyclePhase::PreCommit,
             vec![crate::config::HookDefinition {
-                command: "run-pre-commit".into(),
+                command: "run-pre-commit".try_into().unwrap(),
                 parallel_execution_allowed: false,
             }],
         );
@@ -292,7 +290,7 @@ mod tests {
         hooks_map.insert(
             LifeCyclePhase::CommitMsg,
             vec![crate::config::HookDefinition {
-                command: "check-commit-message".into(),
+                command: "check-commit-message".try_into().unwrap(),
                 parallel_execution_allowed: false,
             }],
         );
@@ -344,11 +342,11 @@ mod tests {
     fn given_summary_success_when_rendering_then_counts_phases_and_durations() {
         let hooks = vec![
             HookDefinition {
-                command: "seq-ok".into(),
+                command: "seq-ok".try_into().unwrap(),
                 parallel_execution_allowed: false,
             },
             HookDefinition {
-                command: "parallel-ok".into(),
+                command: "parallel-ok".try_into().unwrap(),
                 parallel_execution_allowed: true,
             },
         ];
@@ -383,15 +381,15 @@ mod tests {
     fn given_summary_sequential_failure_when_rendering_then_reports_skipped_and_first_failure() {
         let hooks = vec![
             HookDefinition {
-                command: "seq-fail".into(),
+                command: "seq-fail".try_into().unwrap(),
                 parallel_execution_allowed: false,
             },
             HookDefinition {
-                command: "seq-skipped".into(),
+                command: "seq-skipped".try_into().unwrap(),
                 parallel_execution_allowed: false,
             },
             HookDefinition {
-                command: "parallel-skipped".into(),
+                command: "parallel-skipped".try_into().unwrap(),
                 parallel_execution_allowed: true,
             },
         ];
@@ -456,7 +454,9 @@ mod tests {
     #[test]
     fn given_spawn_failure_when_rendering_summary_then_status_and_error_are_redacted() {
         let hooks = vec![HookDefinition {
-            command: "SECRET=value deploy --token super-secret-value".into(),
+            command: "SECRET=value deploy --token super-secret-value"
+                .try_into()
+                .unwrap(),
             parallel_execution_allowed: false,
         }];
         let runner = FakeRunner::with_default_outcomes(vec![PlannedResult::SpawnError(
@@ -487,11 +487,11 @@ mod tests {
     fn given_stdin_payload_when_executing_then_each_command_receives_the_same_bytes() {
         let hooks = vec![
             HookDefinition {
-                command: "first".into(),
+                command: "first".try_into().unwrap(),
                 parallel_execution_allowed: false,
             },
             HookDefinition {
-                command: "second".into(),
+                command: "second".try_into().unwrap(),
                 parallel_execution_allowed: false,
             },
         ];
@@ -632,7 +632,7 @@ mod tests {
         hooks_map.insert(
             LifeCyclePhase::PreCommit,
             vec![crate::config::HookDefinition {
-                command: "hook command".into(),
+                command: "hook command".try_into().unwrap(),
                 parallel_execution_allowed: false,
             }],
         );
@@ -652,7 +652,7 @@ mod tests {
         )]);
 
         let result = execute_command(
-            &HookCommand::from("deploy --token super-secret-value"),
+            &HookCommand::try_from("deploy --token super-secret-value").unwrap(),
             &runner,
             &[],
             None,
@@ -679,7 +679,7 @@ mod tests {
         )]);
 
         let result = execute_command(
-            &HookCommand::from("TOKEN=super-secret API_KEY=123 deploy --arg value"),
+            &HookCommand::try_from("TOKEN=super-secret API_KEY=123 deploy --arg value").unwrap(),
             &runner,
             &[],
             None,
@@ -703,9 +703,10 @@ mod tests {
         )]);
 
         let result = execute_command(
-            &HookCommand::from(
+            &HookCommand::try_from(
                 "TOKEN=\"super secret\" API_KEY='another secret' ./deploy --arg value",
-            ),
+            )
+            .unwrap(),
             &runner,
             &[],
             None,
@@ -767,16 +768,14 @@ mod tests {
     }
 
     #[test]
-    fn given_empty_command_when_executing_then_no_command_defined_error() {
-        let runner = FakeRunner::with_default_outcomes(vec![]);
-        let result = execute_command(&HookCommand::from("   "), &runner, &[], None);
-        assert!(matches!(result, Err(Error::NoCommandDefined)));
-    }
-
-    #[test]
     fn given_missing_exit_code_when_executing_then_terminated_by_signal_error() {
         let runner = FakeRunner::with_default_outcomes(vec![PlannedResult::Exit(None)]);
-        let result = execute_command(&HookCommand::from("run-hook"), &runner, &[], None);
+        let result = execute_command(
+            &HookCommand::try_from("run-hook").unwrap(),
+            &runner,
+            &[],
+            None,
+        );
         assert!(matches!(result, Err(Error::ExecutionTerminatedBySignal)));
     }
 
@@ -788,7 +787,7 @@ mod tests {
             ["parallel-1", "parallel-2", "parallel-3", "parallel-4"]
                 .iter()
                 .map(|command| HookDefinition {
-                    command: (*command).into(),
+                    command: (*command).try_into().unwrap(),
                     parallel_execution_allowed: true,
                 })
                 .collect(),
@@ -824,16 +823,16 @@ mod tests {
         let mut hook_definitions: Vec<HookDefinition> = ["parallel-1", "parallel-2", "parallel-3"]
             .iter()
             .map(|command| HookDefinition {
-                command: (*command).into(),
+                command: (*command).try_into().unwrap(),
                 parallel_execution_allowed: true,
             })
             .collect();
         hook_definitions.push(HookDefinition {
-            command: "sequential-1".into(),
+            command: "sequential-1".try_into().unwrap(),
             parallel_execution_allowed: false,
         });
         hook_definitions.push(HookDefinition {
-            command: "sequential-2".into(),
+            command: "sequential-2".try_into().unwrap(),
             parallel_execution_allowed: false,
         });
 
@@ -872,11 +871,11 @@ mod tests {
     fn given_failed_sequential_hook_when_executing_then_parallel_hooks_do_not_run() {
         let hooks = vec![
             HookDefinition {
-                command: "sequential".into(),
+                command: "sequential".try_into().unwrap(),
                 parallel_execution_allowed: false,
             },
             HookDefinition {
-                command: "parallel".into(),
+                command: "parallel".try_into().unwrap(),
                 parallel_execution_allowed: true,
             },
         ];
@@ -896,15 +895,15 @@ mod tests {
         let barrier = Arc::new(Barrier::new(2));
         let hooks = vec![
             HookDefinition {
-                command: "sequential".into(),
+                command: "sequential".try_into().unwrap(),
                 parallel_execution_allowed: false,
             },
             HookDefinition {
-                command: "parallel-ok".into(),
+                command: "parallel-ok".try_into().unwrap(),
                 parallel_execution_allowed: true,
             },
             HookDefinition {
-                command: "parallel-fail".into(),
+                command: "parallel-fail".try_into().unwrap(),
                 parallel_execution_allowed: true,
             },
         ];

--- a/crates/git-smee-core/src/executor/scheduler.rs
+++ b/crates/git-smee-core/src/executor/scheduler.rs
@@ -142,9 +142,6 @@ pub(super) fn execute_command(
     hook_args: &[String],
     stdin_payload: Option<&[u8]>,
 ) -> Result<(), Error> {
-    if command.is_empty() {
-        return Err(Error::NoCommandDefined);
-    }
     let exit_code = runner
         .run(command, hook_args, stdin_payload)
         .map_err(|source| Error::CommandSpawnFailed {

--- a/crates/git-smee-core/src/installer.rs
+++ b/crates/git-smee-core/src/installer.rs
@@ -131,7 +131,7 @@ pub trait HookInstaller {
 /// hooks.insert(
 ///     LifeCyclePhase::PreCommit,
 ///     vec![HookDefinition {
-///         command: "echo pre-commit".into(),
+///         command: "echo pre-commit".try_into().unwrap(),
 ///         parallel_execution_allowed: false,
 ///     }],
 /// );
@@ -259,7 +259,7 @@ mod tests {
         hooks_map.insert(
             crate::config::LifeCyclePhase::PreCommit,
             vec![crate::config::HookDefinition {
-                command: "echo Pre-commit hook".into(),
+                command: "echo Pre-commit hook".try_into().unwrap(),
                 parallel_execution_allowed: false,
             }],
         );
@@ -293,14 +293,14 @@ mod tests {
         hooks_map.insert(
             crate::config::LifeCyclePhase::PreCommit,
             vec![crate::config::HookDefinition {
-                command: "echo Pre-commit hook".into(),
+                command: "echo Pre-commit hook".try_into().unwrap(),
                 parallel_execution_allowed: false,
             }],
         );
         hooks_map.insert(
             crate::config::LifeCyclePhase::PrePush,
             vec![crate::config::HookDefinition {
-                command: "echo Pre-push hook".into(),
+                command: "echo Pre-push hook".try_into().unwrap(),
                 parallel_execution_allowed: false,
             }],
         );
@@ -338,21 +338,21 @@ mod tests {
         hooks_map.insert(
             crate::config::LifeCyclePhase::PrePush,
             vec![crate::config::HookDefinition {
-                command: "echo Pre-push hook".into(),
+                command: "echo Pre-push hook".try_into().unwrap(),
                 parallel_execution_allowed: false,
             }],
         );
         hooks_map.insert(
             crate::config::LifeCyclePhase::ApplypatchMsg,
             vec![crate::config::HookDefinition {
-                command: "echo Applypatch hook".into(),
+                command: "echo Applypatch hook".try_into().unwrap(),
                 parallel_execution_allowed: false,
             }],
         );
         hooks_map.insert(
             crate::config::LifeCyclePhase::PreCommit,
             vec![crate::config::HookDefinition {
-                command: "echo Pre-commit hook".into(),
+                command: "echo Pre-commit hook".try_into().unwrap(),
                 parallel_execution_allowed: false,
             }],
         );
@@ -505,7 +505,7 @@ mod tests {
         hooks_map.insert(
             crate::config::LifeCyclePhase::PreCommit,
             vec![crate::config::HookDefinition {
-                command: "echo Pre-commit hook".into(),
+                command: "echo Pre-commit hook".try_into().unwrap(),
                 parallel_execution_allowed: false,
             }],
         );
@@ -533,7 +533,7 @@ mod tests {
         hooks_map.insert(
             crate::config::LifeCyclePhase::PreCommit,
             vec![crate::config::HookDefinition {
-                command: "echo Pre-commit hook".into(),
+                command: "echo Pre-commit hook".try_into().unwrap(),
                 parallel_execution_allowed: false,
             }],
         );

--- a/crates/git-smee-core/tests/config_integration.rs
+++ b/crates/git-smee-core/tests/config_integration.rs
@@ -134,15 +134,14 @@ command = "   "
 
     let result = SmeeConfig::from_toml(&config_path);
 
-    assert!(matches!(
-        result,
-        Err(config::Error::ValidationError(
-            config::ValidationError::EmptyCommand {
-                hook_name,
-                entry_index
-            }
-        )) if hook_name == "pre-commit" && entry_index == 2
-    ));
+    match result {
+        Err(config::Error::ParseError(error)) => {
+            let message = error.to_string();
+            assert!(message.contains("pre-commit"));
+            assert!(message.contains("command must not be empty"));
+        }
+        _ => panic!("expected parse error for whitespace-only hook command"),
+    }
 }
 
 #[test]

--- a/crates/git-smee-core/tests/installer_integration.rs
+++ b/crates/git-smee-core/tests/installer_integration.rs
@@ -729,7 +729,7 @@ fn pre_commit_only_config() -> SmeeConfig {
     hooks.insert(
         git_smee_core::config::LifeCyclePhase::PreCommit,
         vec![git_smee_core::config::HookDefinition {
-            command: "echo pre-commit".into(),
+            command: "echo pre-commit".try_into().unwrap(),
             parallel_execution_allowed: false,
         }],
     );


### PR DESCRIPTION
## Summary
- make `HookCommand` construction fallible for empty and whitespace-only shell source
- deserialize config through a validated wire-to-domain conversion while preserving hook/entry error context and exact valid command bytes
- remove the scheduler's redundant empty-command fallback and migrate programmatic call sites to `TryFrom`

## Test-driven development
- RED: focused constructor and deserialization regressions both failed against the previous infallible type
- GREEN: constructor, TOML, contextual CLI error, and normal execution tests now pass

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`

Fixes #191


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Configuration parsing now reports invalid or empty hook commands with the affected hook name and entry number.
  - Empty and whitespace-only commands are rejected earlier with clearer error messages.
  - Unknown configuration fields are rejected to help identify configuration mistakes.
  - Hook execution now correctly reports processes terminated by signals.

- **Tests**
  - Updated installation, configuration, and execution coverage for improved validation and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->