### PR TITLE
Update crossbeam-epoch for RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary
- update `crossbeam-epoch` from 0.9.18 to 0.9.20 in `Cargo.lock`
- resolve `RUSTSEC-2026-0204` without changing direct dependency declarations or ignoring the advisory

## Test-driven validation
- RED: `cargo audit` failed on 0.9.18 with `RUSTSEC-2026-0204`
- GREEN: `cargo audit` passes after the targeted lockfile update (two pre-existing allowed `git2` warnings remain)

## Validation
- `cargo audit`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`

Fixes #193
