### PR TITLE
Enforce non-empty SmeeConfig hook phases

### DIFF
--- a/crates/git-smee-cli/src/doctor.rs
+++ b/crates/git-smee-cli/src/doctor.rs
@@ -102,7 +102,7 @@ fn build_doctor_report(config_path: &Path) -> DoctorReport {
             report
                 .ok
                 .push(format!("config parses from {}", config_path.display()));
-            if config.hooks.is_empty() {
+            if config.is_empty() {
                 report.errors.push(
                     "configuration contains no hooks; add at least one [[hook-name]] entry"
                         .to_string(),
@@ -110,7 +110,7 @@ fn build_doctor_report(config_path: &Path) -> DoctorReport {
             } else {
                 report.ok.push(format!(
                     "{} configured hook phase(s) are valid",
-                    config.hooks.len()
+                    config.phase_count()
                 ));
             }
             config
@@ -127,7 +127,7 @@ fn build_doctor_report(config_path: &Path) -> DoctorReport {
     let expected_hook_script =
         ExpectedHookScript::from_current_process(config_path, &repository_root);
 
-    let mut phases: Vec<_> = config.hooks.keys().copied().collect();
+    let mut phases: Vec<_> = config.phases().collect();
     phases.sort_by_key(|phase| phase.as_str());
     for phase in phases {
         let inspection = inspect_hook(&repository_root, &hooks_dir, phase);

--- a/crates/git-smee-cli/src/status.rs
+++ b/crates/git-smee-cli/src/status.rs
@@ -77,14 +77,14 @@ fn build_status_report(config_path: &Path) -> Result<StatusReport, Box<dyn std::
     let expected_hook_script =
         ExpectedHookScript::from_current_process(config_path, &repository_root);
 
-    let mut phases: Vec<_> = config.hooks.keys().copied().collect();
+    let mut phases: Vec<_> = config.phases().collect();
     phases.sort_by_key(|phase| phase.as_str());
 
     let mut hooks = Vec::new();
     let mut next_actions = Vec::new();
     for phase in &phases {
         let inspection = inspect_hook(&repository_root, &hooks_dir, *phase);
-        let configured_command_count = config.hooks.get(phase).map_or(0, Vec::len);
+        let configured_command_count = config.hooks_for(*phase).map_or(0, <[_]>::len);
         let mut stale_reasons = Vec::new();
         let (state, next_action) = match inspection.state() {
             HookInspectionState::Missing => (

--- a/crates/git-smee-cli/tests/cli_integration.rs
+++ b/crates/git-smee-cli/tests/cli_integration.rs
@@ -117,8 +117,8 @@ fn given_unmanaged_hooks_when_migrate_hooks_then_prints_parseable_toml_suggestio
     let suggested_config = test_repo.path.join("suggested.git-smee.toml");
     fs::write(&suggested_config, output).unwrap();
     let parsed = git_smee_core::SmeeConfig::from_toml(&suggested_config).unwrap();
-    assert!(parsed.hooks.contains_key(&LifeCyclePhase::PreCommit));
-    assert!(parsed.hooks.contains_key(&LifeCyclePhase::CommitMsg));
+    assert!(parsed.hooks_for(LifeCyclePhase::PreCommit).is_some());
+    assert!(parsed.hooks_for(LifeCyclePhase::CommitMsg).is_some());
 }
 
 #[test]

--- a/crates/git-smee-core/src/config.rs
+++ b/crates/git-smee-core/src/config.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 #[derive(Serialize)]
 pub struct SmeeConfig {
     #[serde(flatten)]
-    pub hooks: HashMap<LifeCyclePhase, Vec<HookDefinition>>,
+    hooks: HashMap<LifeCyclePhase, Vec<HookDefinition>>,
 }
 
 #[derive(Deserialize)]
@@ -59,11 +59,46 @@ impl<'de> Deserialize<'de> for SmeeConfig {
                 Ok((phase, definitions))
             })
             .collect::<Result<HashMap<_, _>, D::Error>>()?;
-        Ok(Self { hooks })
+        Self::try_new(hooks).map_err(de::Error::custom)
     }
 }
 
 impl SmeeConfig {
+    /// Constructs a configuration while enforcing that configured phases are non-empty.
+    pub fn try_new(
+        hooks: HashMap<LifeCyclePhase, Vec<HookDefinition>>,
+    ) -> Result<Self, ValidationError> {
+        for (phase, definitions) in &hooks {
+            if definitions.is_empty() {
+                return Err(ValidationError::EmptyHookEntries {
+                    hook_name: phase.to_string(),
+                });
+            }
+        }
+
+        Ok(Self { hooks })
+    }
+
+    /// Returns the configured hooks for a lifecycle phase, if that phase is configured.
+    pub fn hooks_for(&self, phase: LifeCyclePhase) -> Option<&[HookDefinition]> {
+        self.hooks.get(&phase).map(Vec::as_slice)
+    }
+
+    /// Iterates over configured lifecycle phases.
+    pub fn phases(&self) -> impl Iterator<Item = LifeCyclePhase> + '_ {
+        self.hooks.keys().copied()
+    }
+
+    /// Returns the number of configured lifecycle phases.
+    pub fn phase_count(&self) -> usize {
+        self.hooks.len()
+    }
+
+    /// Returns whether no lifecycle phase is configured.
+    pub fn is_empty(&self) -> bool {
+        self.hooks.is_empty()
+    }
+
     /// Load configuration from a TOML file.
     ///
     /// Reads and parses the `.smee.toml` configuration file at the given path.
@@ -93,7 +128,7 @@ impl SmeeConfig {
     /// fs::write(&config_path, toml_content).unwrap();
     ///
     /// let config = SmeeConfig::from_toml(&config_path).unwrap();
-    /// assert!(config.hooks.contains_key(&LifeCyclePhase::PreCommit));
+    /// assert!(config.hooks_for(LifeCyclePhase::PreCommit).is_some());
     /// ```
     ///
     pub fn from_toml(path: &Path) -> Result<Self, Error> {
@@ -108,21 +143,7 @@ impl SmeeConfig {
             return Err(Error::NotATomlFileExtension);
         }
         let data = fs::read(path).map_err(Error::ReadError)?;
-        let config: SmeeConfig = toml::from_slice(&data).map_err(Error::ParseError)?;
-        config.validate()?;
-        Ok(config)
-    }
-
-    pub fn validate(&self) -> Result<(), ValidationError> {
-        for (phase, hooks) in &self.hooks {
-            if hooks.is_empty() {
-                return Err(ValidationError::EmptyHookEntries {
-                    hook_name: phase.to_string(),
-                });
-            }
-        }
-
-        Ok(())
+        toml::from_slice(&data).map_err(Error::ParseError)
     }
 }
 
@@ -137,7 +158,7 @@ impl Default for SmeeConfig {
                 parallel_execution_allowed: false,
             }],
         );
-        Self { hooks: hash_map }
+        Self::try_new(hash_map).expect("default hook definitions should be non-empty")
     }
 }
 
@@ -390,14 +411,21 @@ mod tests {
     #[test]
     fn test_create_from_toml() {
         let config: SmeeConfig = toml::from_str(EXAMPLE_TOML).unwrap();
-        assert_eq!(config.hooks.len(), 1);
-        assert_eq!(config.hooks[&LifeCyclePhase::PreCommit].len(), 2);
-        let hook_definition = config.hooks[&LifeCyclePhase::PreCommit]
+        assert_eq!(config.phase_count(), 1);
+        assert_eq!(
+            config.hooks_for(LifeCyclePhase::PreCommit).unwrap().len(),
+            2
+        );
+        let hook_definition = config
+            .hooks_for(LifeCyclePhase::PreCommit)
+            .unwrap()
             .first()
             .expect("Hook definition should be present");
         assert_eq!(hook_definition.command, "cargo build");
         assert!(!hook_definition.parallel_execution_allowed);
-        let hook_definition = config.hooks[&LifeCyclePhase::PreCommit]
+        let hook_definition = config
+            .hooks_for(LifeCyclePhase::PreCommit)
+            .unwrap()
             .get(1)
             .expect("Second Hook Definition should be present");
         assert_eq!(hook_definition.command, "cargo test");
@@ -474,7 +502,7 @@ mod tests {
     #[test]
     fn given_default_config_when_try_into_string_then_string() {
         let config = SmeeConfig::default();
-        assert_eq!(config.hooks.len(), 1);
+        assert_eq!(config.phase_count(), 1);
 
         //when
         let serialized_config: String = (&config).try_into().unwrap();
@@ -579,7 +607,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            config.hooks[&LifeCyclePhase::PreCommit][0]
+            config.hooks_for(LifeCyclePhase::PreCommit).unwrap()[0]
                 .command
                 .as_shell_source(),
             "  echo preserved  "
@@ -587,23 +615,20 @@ mod tests {
     }
 
     #[test]
-    fn given_hook_without_entries_when_validating_then_error_contains_hook() {
+    fn given_hook_without_entries_when_constructing_then_error_contains_hook() {
         let mut hooks = HashMap::new();
         hooks.insert(LifeCyclePhase::PrePush, vec![]);
-        let config = SmeeConfig { hooks };
 
-        let result = config.validate();
+        let result = SmeeConfig::try_new(hooks);
 
-        assert_eq!(
+        assert!(matches!(
             result,
-            Err(ValidationError::EmptyHookEntries {
-                hook_name: "pre-push".to_string(),
-            })
-        );
+            Err(ValidationError::EmptyHookEntries { hook_name }) if hook_name == "pre-push"
+        ));
     }
 
     #[test]
-    fn given_valid_config_when_validating_then_success() {
+    fn given_valid_config_when_constructing_then_success() {
         let mut hooks = HashMap::new();
         hooks.insert(
             LifeCyclePhase::PreCommit,
@@ -612,8 +637,6 @@ mod tests {
                 parallel_execution_allowed: false,
             }],
         );
-        let config = SmeeConfig { hooks };
-
-        assert!(config.validate().is_ok());
+        assert!(SmeeConfig::try_new(hooks).is_ok());
     }
 }

--- a/crates/git-smee-core/src/executor.rs
+++ b/crates/git-smee-core/src/executor.rs
@@ -104,7 +104,7 @@ fn execute_hook_with_runner<R: CommandRunner>(
     hook_args: &[String],
     stdin_payload: Option<&[u8]>,
 ) -> Result<(), Error> {
-    match smee_config.hooks.get(&phase) {
+    match smee_config.hooks_for(phase) {
         None => Err(Error::NoHooksConfigured(phase)),
         Some(hooks) => run_hooks_with_runner(hooks, runner, hook_args, stdin_payload),
     }
@@ -117,7 +117,7 @@ fn execute_hook_with_runner_and_summary<R: CommandRunner>(
     hook_args: &[String],
     stdin_payload: Option<&[u8]>,
 ) -> Result<HookRunSummary, Error> {
-    match smee_config.hooks.get(&phase) {
+    match smee_config.hooks_for(phase) {
         None => Err(Error::NoHooksConfigured(phase)),
         Some(hooks) => Ok(run_hooks_with_runner_with_summary(
             hooks,
@@ -254,9 +254,7 @@ mod tests {
 
     #[test]
     fn given_empty_smee_config_when_executing_hook_then_no_hooks_configured_error() {
-        let config = SmeeConfig {
-            hooks: std::collections::HashMap::new(),
-        };
+        let config = SmeeConfig::try_new(std::collections::HashMap::new()).unwrap();
 
         let result = execute_hook(&config, LifeCyclePhase::PreCommit);
         assert!(matches!(
@@ -275,7 +273,7 @@ mod tests {
                 parallel_execution_allowed: false,
             }],
         );
-        let config = SmeeConfig { hooks: hooks_map };
+        let config = SmeeConfig::try_new(hooks_map).unwrap();
         let runner = FakeRunner::with_default_outcomes(vec![PlannedResult::Exit(Some(0))]);
 
         let result =
@@ -294,7 +292,7 @@ mod tests {
                 parallel_execution_allowed: false,
             }],
         );
-        let config = SmeeConfig { hooks: hooks_map };
+        let config = SmeeConfig::try_new(hooks_map).unwrap();
         let runner = FakeRunner::with_default_outcomes(vec![PlannedResult::Exit(Some(0))]);
         let hook_args = vec!["COMMIT_EDITMSG".to_string(), "message".to_string()];
 
@@ -636,7 +634,7 @@ mod tests {
                 parallel_execution_allowed: false,
             }],
         );
-        let config = SmeeConfig { hooks: hooks_map };
+        let config = SmeeConfig::try_new(hooks_map).unwrap();
         let runner = FakeRunner::with_default_outcomes(vec![PlannedResult::Exit(Some(127))]);
 
         let result =
@@ -792,7 +790,7 @@ mod tests {
                 })
                 .collect(),
         );
-        let config = SmeeConfig { hooks: hooks_map };
+        let config = SmeeConfig::try_new(hooks_map).unwrap();
         let runner = FakeRunner::with_command_outcomes(vec![
             ("parallel-1", vec![PlannedResult::Exit(Some(0))]),
             ("parallel-2", vec![PlannedResult::Exit(Some(0))]),
@@ -837,7 +835,7 @@ mod tests {
         });
 
         hooks_map.insert(LifeCyclePhase::PreCommit, hook_definitions);
-        let config = SmeeConfig { hooks: hooks_map };
+        let config = SmeeConfig::try_new(hooks_map).unwrap();
         let runner = FakeRunner::with_command_outcomes(vec![
             ("sequential-1", vec![PlannedResult::Exit(Some(0))]),
             ("sequential-2", vec![PlannedResult::Exit(Some(0))]),

--- a/crates/git-smee-core/src/installer.rs
+++ b/crates/git-smee-core/src/installer.rs
@@ -135,7 +135,7 @@ pub trait HookInstaller {
 ///         parallel_execution_allowed: false,
 ///     }],
 /// );
-/// let config = SmeeConfig { hooks };
+/// let config = SmeeConfig::try_new(hooks).unwrap();
 ///
 /// let installer = FileSystemHookInstaller::from_path(temp_dir.path().to_path_buf()).unwrap();
 /// install_hooks(&config, &installer).unwrap();
@@ -155,11 +155,11 @@ pub fn install_hooks_with_options<T: HookInstaller>(
     hook_installer: &T,
     options: &HookScriptOptions,
 ) -> Result<(), Error> {
-    if config.hooks.is_empty() {
+    if config.is_empty() {
         return Err(Error::NoHooksPresent);
     }
     let platform = Platform::current();
-    let mut phases: Vec<_> = config.hooks.keys().copied().collect();
+    let mut phases: Vec<_> = config.phases().collect();
     phases.sort_by_key(|phase| phase.as_str());
     let active_hook_names: Vec<_> = phases.iter().map(|phase| phase.to_string()).collect();
     hook_installer.prepare_install_hooks(&active_hook_names)?;
@@ -239,9 +239,7 @@ mod tests {
 
     #[test]
     fn given_empty_smee_config_when_installing_hooks_then_no_hooks_present_error() {
-        let config = SmeeConfig {
-            hooks: std::collections::HashMap::new(),
-        };
+        let config = SmeeConfig::try_new(std::collections::HashMap::new()).unwrap();
 
         let installer = AssertingHookInstaller::new(|_, _| panic!("No hooks should be installed"));
 
@@ -263,7 +261,7 @@ mod tests {
                 parallel_execution_allowed: false,
             }],
         );
-        let config = SmeeConfig { hooks: hooks_map };
+        let config = SmeeConfig::try_new(hooks_map).unwrap();
         let options = HookScriptOptions::new(
             PathBuf::from("/tmp/git-smee-bin"),
             PathBuf::from("/tmp/custom-config.toml"),
@@ -304,7 +302,7 @@ mod tests {
                 parallel_execution_allowed: false,
             }],
         );
-        let config = SmeeConfig { hooks: hooks_map };
+        let config = SmeeConfig::try_new(hooks_map).unwrap();
         let options = HookScriptOptions::new(
             PathBuf::from("/tmp/git-smee-bin"),
             PathBuf::from("/tmp/custom-config.toml"),
@@ -356,7 +354,7 @@ mod tests {
                 parallel_execution_allowed: false,
             }],
         );
-        let config = SmeeConfig { hooks: hooks_map };
+        let config = SmeeConfig::try_new(hooks_map).unwrap();
         let options = HookScriptOptions::new(
             PathBuf::from("/tmp/git-smee-bin"),
             PathBuf::from("/tmp/custom-config.toml"),
@@ -509,7 +507,7 @@ mod tests {
                 parallel_execution_allowed: false,
             }],
         );
-        let config = SmeeConfig { hooks: hooks_map };
+        let config = SmeeConfig::try_new(hooks_map).unwrap();
         let options = HookScriptOptions::new(
             PathBuf::from("/tmp/it's 100% ready/git-smee"),
             PathBuf::from("/tmp/configs/it's 100% ready.toml"),
@@ -537,7 +535,7 @@ mod tests {
                 parallel_execution_allowed: false,
             }],
         );
-        let config = SmeeConfig { hooks: hooks_map };
+        let config = SmeeConfig::try_new(hooks_map).unwrap();
         let options = HookScriptOptions::new(
             PathBuf::from(r#"C:\Program Files\100%"quoted"\git-smee.exe"#),
             PathBuf::from(r#"C:\repo\configs\it's 100% "ready".toml"#),

--- a/crates/git-smee-core/tests/config_integration.rs
+++ b/crates/git-smee-core/tests/config_integration.rs
@@ -1,10 +1,79 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::{fs, io::Write};
 
 use git_smee_core::{
     SmeeConfig,
-    config::{self, LifeCyclePhase},
+    config::{self, HookDefinition, LifeCyclePhase, ValidationError},
 };
+
+fn hook(command: &str) -> HookDefinition {
+    HookDefinition {
+        command: command.try_into().unwrap(),
+        parallel_execution_allowed: false,
+    }
+}
+
+#[test]
+fn given_empty_phase_when_constructing_config_then_phase_is_rejected() {
+    let hooks = HashMap::from([(LifeCyclePhase::PrePush, Vec::new())]);
+
+    let result = SmeeConfig::try_new(hooks);
+
+    assert!(matches!(
+        result,
+        Err(ValidationError::EmptyHookEntries { hook_name }) if hook_name == "pre-push"
+    ));
+}
+
+#[test]
+fn given_explicitly_empty_phase_when_deserializing_then_actionable_error_is_returned() {
+    let error = toml::from_str::<SmeeConfig>("pre-push = []")
+        .err()
+        .expect("empty phase should not deserialize");
+
+    let message = error.to_string();
+    assert!(message.contains("pre-push"));
+    assert!(message.contains("has no entries"));
+}
+
+#[test]
+fn given_valid_multi_phase_config_when_round_tripping_then_shape_and_source_are_preserved() {
+    let hooks = HashMap::from([
+        (LifeCyclePhase::PreCommit, vec![hook("  cargo test  ")]),
+        (LifeCyclePhase::PrePush, vec![hook("cargo fmt --check")]),
+    ]);
+    let config = SmeeConfig::try_new(hooks).unwrap();
+
+    let serialized: String = (&config).try_into().unwrap();
+    let reparsed: SmeeConfig = toml::from_str(&serialized).unwrap();
+
+    assert_eq!(
+        reparsed.hooks_for(LifeCyclePhase::PreCommit).unwrap()[0]
+            .command
+            .as_shell_source(),
+        "  cargo test  "
+    );
+    assert_eq!(
+        reparsed.hooks_for(LifeCyclePhase::PrePush).unwrap().len(),
+        1
+    );
+}
+
+#[test]
+fn given_valid_config_when_looking_up_phases_then_missing_and_configured_are_distinct() {
+    let config = SmeeConfig::try_new(HashMap::from([(
+        LifeCyclePhase::PreCommit,
+        vec![hook("cargo test")],
+    )]))
+    .unwrap();
+
+    assert_eq!(
+        config.hooks_for(LifeCyclePhase::PreCommit).unwrap().len(),
+        1
+    );
+    assert!(config.hooks_for(LifeCyclePhase::PrePush).is_none());
+}
 
 #[test]
 fn given_simple_toml_when_reading_then_succeed() {
@@ -12,14 +81,12 @@ fn given_simple_toml_when_reading_then_succeed() {
     let config = SmeeConfig::from_toml(&path).expect("Should load successfully");
 
     let pre_commit_hooks = config
-        .hooks
-        .get(&LifeCyclePhase::PreCommit)
+        .hooks_for(LifeCyclePhase::PreCommit)
         .expect("pre-commit hooks should be present");
     assert_eq!(pre_commit_hooks.len(), 2);
 
     let pre_push_hooks = config
-        .hooks
-        .get(&LifeCyclePhase::PrePush)
+        .hooks_for(LifeCyclePhase::PrePush)
         .expect("pre-push hooks should be present");
     assert_eq!(pre_push_hooks.len(), 1);
 }
@@ -195,8 +262,8 @@ command = "echo post-receive"
 
     let config = SmeeConfig::from_toml(&config_path).expect("expected config to parse");
 
-    assert!(config.hooks.contains_key(&LifeCyclePhase::PreReceive));
-    assert!(config.hooks.contains_key(&LifeCyclePhase::Update));
-    assert!(config.hooks.contains_key(&LifeCyclePhase::ProcReceive));
-    assert!(config.hooks.contains_key(&LifeCyclePhase::PostReceive));
+    assert!(config.hooks_for(LifeCyclePhase::PreReceive).is_some());
+    assert!(config.hooks_for(LifeCyclePhase::Update).is_some());
+    assert!(config.hooks_for(LifeCyclePhase::ProcReceive).is_some());
+    assert!(config.hooks_for(LifeCyclePhase::PostReceive).is_some());
 }

--- a/crates/git-smee-core/tests/installer_integration.rs
+++ b/crates/git-smee-core/tests/installer_integration.rs
@@ -733,7 +733,7 @@ fn pre_commit_only_config() -> SmeeConfig {
             parallel_execution_allowed: false,
         }],
     );
-    SmeeConfig { hooks }
+    SmeeConfig::try_new(hooks).unwrap()
 }
 
 fn read_config_from_repo(repo: &Path) -> SmeeConfig {


### PR DESCRIPTION
## Summary
- make `SmeeConfig` hook storage private and add validated construction/read APIs
- reject explicitly empty lifecycle phases during both Rust construction and TOML deserialization
- migrate executor, installer, CLI diagnostics, tests, and public examples away from direct map access

## TDD
- RED: `cargo test -p git-smee-core --test config_integration` failed because `try_new` and `hooks_for` did not exist
- GREEN: focused config integration suite passed with construction, deserialization, round-trip, and lookup regressions

## Validation
- `cargo +1.92.0 fmt --all -- --check`
- `cargo +1.92.0 clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo +1.92.0 test --workspace --all-targets --all-features --locked` (238 tests passed)

The first full-suite attempt encountered a linker bus error after the disk reached 100%; cleaning this worktree's rebuildable `target/` artifacts and rerunning serially produced the full green result above.

Fixes #195


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured configuration APIs for inspecting configured lifecycle phases and hooks.
  * Configuration now rejects lifecycle phases that contain no hooks, with clearer validation errors.

* **Bug Fixes**
  * Updated diagnostics, status reporting, installation, and hook execution to consistently recognize configured phases and hook counts.
  * Improved configuration loading and round-trip validation for multi-phase setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->