### PR TITLE
ci: refresh upload-artifact for Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
           cargo llvm-cov --workspace --all-features --locked --lcov --output-path lcov.info -- --skip repository::tests::
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-lcov
           path: lcov.info


### PR DESCRIPTION
## Summary
- refresh the pinned coverage upload action from v5 to v7.0.1
- use the verified full SHA `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`
- preserve the coverage artifact name and path

## TDD / validation
- RED: post-merge CI run 30789953885 emitted the Node.js 20 forced-compatibility annotation; a local structural assertion failed against the old pin
- GREEN: structural assertion confirms the v7.0.1 pin appears once, the v5 pin is absent, and `coverage-lcov` / `lcov.info` inputs are unchanged
- upstream GitHub API verification confirms the pinned commit's `action.yml` declares `runs.using: node24`
- all workflow YAML files parse with PyYAML
- `cargo fmt --all -- --check`
- local actionlint was unavailable; hosted `Workflow lint (actionlint + shellcheck)` is the authoritative gate

Fixes #199
